### PR TITLE
1.12 tile entity nbt fix (because of obfuscation)

### DIFF
--- a/item-nbt-api/src/main/java/de/tr7zw/itemnbtapi/NBTReflectionUtil.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/itemnbtapi/NBTReflectionUtil.java
@@ -347,7 +347,7 @@ public class NBTReflectionUtil {
             Object cworld = getCraftWorld().cast(tile.getWorld());
             Object nmsworld = cworld.getClass().getMethod("getHandle").invoke(cworld);
             Object o = nmsworld.getClass().getMethod("getTileEntity", pos.getClass()).invoke(nmsworld, pos);
-            method = getTileEntity().getMethod(MethodNames.getTileDataMethodName(), getNBTTagCompound());
+            method = getTileEntity().getMethod(MethodNames.getTileDataGetterMethodName(), getNBTTagCompound());
             Object tag = getNBTTagCompound().newInstance();
             Object answer = method.invoke(o, tag);
             if (answer == null)
@@ -366,7 +366,7 @@ public class NBTReflectionUtil {
             Object cworld = getCraftWorld().cast(tile.getWorld());
             Object nmsworld = cworld.getClass().getMethod("getHandle").invoke(cworld);
             Object o = nmsworld.getClass().getMethod("getTileEntity", pos.getClass()).invoke(nmsworld, pos);
-            method = getTileEntity().getMethod("a", getNBTTagCompound());
+            method = getTileEntity().getMethod(MethodNames.getTileDataSetterMethodName(), getNBTTagCompound());
             method.invoke(o, comp);
         } catch (Exception e) {
             e.printStackTrace();

--- a/item-nbt-api/src/main/java/de/tr7zw/itemnbtapi/utils/MethodNames.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/itemnbtapi/utils/MethodNames.java
@@ -13,7 +13,7 @@ public class MethodNames {
     
     public static String getTileDataSetterMethodName() {
         if (MINECRAFT_VERSION != MinecraftVersion.MC1_12_R1) {
-            return "b";
+            return "a";
         }
         return "load";
     }

--- a/item-nbt-api/src/main/java/de/tr7zw/itemnbtapi/utils/MethodNames.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/itemnbtapi/utils/MethodNames.java
@@ -4,11 +4,18 @@ public class MethodNames {
 
     private final static MinecraftVersion MINECRAFT_VERSION = MinecraftVersion.getVersion();
 
-    public static String getTileDataMethodName() {
+    public static String getTileDataGetterMethodName() {
         if (MINECRAFT_VERSION == MinecraftVersion.MC1_8_R3) {
             return "b";
         }
         return "save";
+    }
+    
+    public static String getTileDataSetterMethodName() {
+        if (MINECRAFT_VERSION != MinecraftVersion.MC1_12_R1) {
+            return "b";
+        }
+        return "load";
     }
 
     public static String getTypeMethodName() {


### PR DESCRIPTION
In 1.12 the method to set the nbt compound is no longer obfuscated. Therefore it is instead of `a(NBTCompound)` -> `load(NBTCompound)`