### PR TITLE
Implement "remove" method in NBTList iterator

### DIFF
--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTList.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTList.java
@@ -235,6 +235,11 @@ public abstract class NBTList<T> implements List<T> {
 					throw new NoSuchElementException();
 				return get(++index);
 			}
+
+			@Override
+			public void remove() {
+				NBTList.this.remove(index);
+			}
 		};
 	}
 


### PR DESCRIPTION
In the current implementation calling `removeIf(...)` on `NBTList` object will fail, because `remove` method the in underlying the `Iterator` is not implemented.