### PR TITLE
Correct documentation to specify JSON validity

### DIFF
--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTCompound.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTCompound.java
@@ -697,7 +697,7 @@ public class NBTCompound {
 
 	/**
 	 * @deprecated Just use toString()
-	 * @return A json valid nbt string for this Compound
+	 * @return A {@link String} representation of the NBT in Mojang JSON. This is different from normal JSON!
 	 */
 	@Deprecated
 	public String asNBTString() {


### PR DESCRIPTION
Closes #80

Corrects documentation to ensure the understood difference between JSON and Mojang JSON.