### PR TITLE
Use the correct TILEENTITY_SET_NBT method on pre-1.1.6 versions

### DIFF
--- a/nbt-injector/src/main/java/de/tr7zw/nbtinjector/ClassGenerator.java
+++ b/nbt-injector/src/main/java/de/tr7zw/nbtinjector/ClassGenerator.java
@@ -179,6 +179,10 @@ public class ClassGenerator {
 				: "void";
 		String writeName = ReflectionMethod.TILEENTITY_GET_NBT.getMethodName();
 		String readName = ReflectionMethod.TILEENTITY_SET_NBT.getMethodName();
+		if(MinecraftVersion.getVersion().getVersionId() < MinecraftVersion.MC1_16_R1.getVersionId()) {
+			readName = ReflectionMethod.TILEENTITY_SET_NBT_LEGACY1151.getMethodName();
+		}
+
 		String writeMethod = "public " + writeReturn + " " + writeName + "(NBTTagCompound compound) {\n"
 				+ "  compound = writeExtraCompound(compound);\n"
 				// + " System.out.println(\"Save: \" +compound);\n"


### PR DESCRIPTION
While troubleshooting #91, I noticed that in https://github.com/tr7zw/Item-NBT-API/blob/master/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTReflectionUtil.java#L246-L251, the TILEENTITY_SET_NBT call is version dependent, but it looks like ClassGenerator.java got missed. This seems to fix the issue

Fixes #91