### PR TITLE
Rename to NBTApiException and fix many formalities

### DIFF
--- a/core/nbt-api/src/main/java/dev/tr7zw/nbtapi/NBTApiException.java
+++ b/core/nbt-api/src/main/java/dev/tr7zw/nbtapi/NBTApiException.java
@@ -2,22 +2,18 @@ package dev.tr7zw.nbtapi;
 
 /**
  * A generic {@link RuntimeException} that can be thrown by most methods in the
- * NBTAPI in case of compatebility/logic issues.
+ * NBT-API in case of compatibility or logic issues.
  * 
  * @author tr7zw
- *
  */
-public class NbtApiException extends RuntimeException {
+public class NBTApiException extends RuntimeException {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = -993309714559452334L;
 
 	/**
 	 * 
 	 */
-	public NbtApiException() {
+	public NBTApiException() {
 		super();
 	}
 
@@ -27,7 +23,7 @@ public class NbtApiException extends RuntimeException {
 	 * @param enableSuppression
 	 * @param writableStackTrace
 	 */
-	public NbtApiException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+	public NBTApiException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
 		super(message, cause, enableSuppression, writableStackTrace);
 	}
 
@@ -35,21 +31,21 @@ public class NbtApiException extends RuntimeException {
 	 * @param message
 	 * @param cause
 	 */
-	public NbtApiException(String message, Throwable cause) {
+	public NBTApiException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
 	/**
 	 * @param message
 	 */
-	public NbtApiException(String message) {
+	public NBTApiException(String message) {
 		super(message);
 	}
 
 	/**
 	 * @param cause
 	 */
-	public NbtApiException(Throwable cause) {
+	public NBTApiException(Throwable cause) {
 		super(cause);
 	}
 

--- a/core/nbt-api/src/main/java/dev/tr7zw/nbtapi/NBTType.java
+++ b/core/nbt-api/src/main/java/dev/tr7zw/nbtapi/NBTType.java
@@ -34,14 +34,13 @@ public enum NBTType {
 	}
 
 	/**
-	 * @param id Internal Minecraft id
-	 * @return Enum representing the id, NBTTagEnd for invalide ids
+	 * @param id Internal Minecraft ID
+	 * @return Enum representing the ID, NBTTagEnd for invalid IDs
 	 */
 	public static NBTType valueOf(int id) {
-		for (NBTType t : values())
-			if (t.getId() == id)
-				return t;
-		return NBTType.NBTTagEnd;
+		NBTType[] values = values();
+		if (id >= values.length || id < 0)
+			return NBTTagEnd;
+		return values[id];
 	}
-
 }

--- a/core/nbt-api/src/main/java/dev/tr7zw/nbtapi/Readable.java
+++ b/core/nbt-api/src/main/java/dev/tr7zw/nbtapi/Readable.java
@@ -10,7 +10,7 @@ public interface Readable {
     /**
      * Getter
      * 
-     * @param key
+     * @param key The String key.
      * @return The stored value or NMS fallback
      */
     String getString(String key);
@@ -18,7 +18,7 @@ public interface Readable {
     /**
      * Getter
      * 
-     * @param key
+     * @param key The String key.
      * @return The stored value or NMS fallback
      */
     Integer getInteger(String key);
@@ -26,7 +26,7 @@ public interface Readable {
     /**
      * Getter
      * 
-     * @param key
+     * @param key The String key.
      * @return The stored value or NMS fallback
      */
     Double getDouble(String key);
@@ -34,7 +34,7 @@ public interface Readable {
     /**
      * Getter
      * 
-     * @param key
+     * @param key The String key.
      * @return The stored value or NMS fallback
      */
     Byte getByte(String key);
@@ -42,7 +42,7 @@ public interface Readable {
     /**
      * Getter
      * 
-     * @param key
+     * @param key The String key.
      * @return The stored value or NMS fallback
      */
     Short getShort(String key);
@@ -50,7 +50,7 @@ public interface Readable {
     /**
      * Getter
      * 
-     * @param key
+     * @param key The String key.
      * @return The stored value or NMS fallback
      */
     Long getLong(String key);
@@ -58,7 +58,7 @@ public interface Readable {
     /**
      * Getter
      * 
-     * @param key
+     * @param key The String key.
      * @return The stored value or NMS fallback
      */
     Float getFloat(String key);
@@ -66,7 +66,7 @@ public interface Readable {
     /**
      * Getter
      * 
-     * @param key
+     * @param key The String key.
      * @return The stored value or NMS fallback
      */
     byte[] getByteArray(String key);
@@ -74,7 +74,7 @@ public interface Readable {
     /**
      * Getter
      * 
-     * @param key
+     * @param key The String key.
      * @return The stored value or NMS fallback
      */
     int[] getIntArray(String key);
@@ -82,7 +82,7 @@ public interface Readable {
     /**
      * Getter
      * 
-     * @param key
+     * @param key The String key.
      * @return The stored value or NMS fallback
      */
     Boolean getBoolean(String key);
@@ -90,56 +90,58 @@ public interface Readable {
     /**
      * Get an ItemStack that was saved at the given key
      * 
-     * @param key
-     * @return
+     * @param key The String key.
+     * @return The stored value or NMS fallback
      */
     ItemStack getItemStack(String key);
 
     /**
-     * Getter
+     * Get the UUID at {@code key}.
      *
-     * @param key
+     * @param key The String key.
      * @return The stored value or NMS fallback
      */
     UUID getUUID(String key);
 
     /**
+     * Get all keys of this tag.
+     *
      * @return Set of all stored Keys
      */
     Set<String> getKeys();
 
     /**
-     * @param name
+     * @param name The String key.
      * @return The Compound instance or null
      */
     Readable getCompound(String name);
 
     /**
-     * @param name
+     * @param name The String key.
      * @return The retrieved String List
      */
     NBTList<String> getStringList(String name);
 
     /**
-     * @param name
+     * @param name The String key.
      * @return The retrieved Integer List
      */
     NBTList<Integer> getIntegerList(String name);
 
     /**
-     * @param name
+     * @param name The String key.
      * @return The retrieved Float List
      */
     NBTList<Float> getFloatList(String name);
 
     /**
-     * @param name
+     * @param name The String key.
      * @return The retrieved Double List
      */
     NBTList<Double> getDoubleList(String name);
 
     /**
-     * @param name
+     * @param name The String key.
      * @return The retrieved Long List
      */
     NBTList<Long> getLongList(String name);
@@ -147,26 +149,26 @@ public interface Readable {
     /**
      * Returns the type of the list, null if not a list
      * 
-     * @param name
-     * @return
+     * @param name The String key.
+     * @return The retrieved type.
      */
     NBTType getListType(String name);
 
     /**
-     * @param name
+     * @param name The String key.
      * @return The retrieved Compound List
      */
     //NBTCompoundList getCompoundList(String name); //FIXME
 
     /**
-     * @param name
+     * @param name The String key.
      * @return The type of the given stored key or null
      */
     NBTType getType(String name);
     
     /**
-     * @param name
-     * @return True when this key is avaliable
+     * @param name The String key.
+     * @return True when this key is available
      */
     boolean hasKey(String name);
 

--- a/core/nbt-api/src/main/java/dev/tr7zw/nbtapi/Writeable.java
+++ b/core/nbt-api/src/main/java/dev/tr7zw/nbtapi/Writeable.java
@@ -17,7 +17,7 @@ public interface Writeable {
     /**
      * Setter
      * 
-     * @param key
+     * @param key The String key.
      * @param value
      */
     void setString(String key, String value);
@@ -25,7 +25,7 @@ public interface Writeable {
     /**
      * Setter
      * 
-     * @param key
+     * @param key The String key.
      * @param value
      */
     void setInteger(String key, Integer value);
@@ -33,7 +33,7 @@ public interface Writeable {
     /**
      * Setter
      * 
-     * @param key
+     * @param key The String key.
      * @param value
      */
     void setDouble(String key, Double value);
@@ -41,7 +41,7 @@ public interface Writeable {
     /**
      * Setter
      * 
-     * @param key
+     * @param key The String key.
      * @param value
      */
     void setByte(String key, Byte value);
@@ -49,7 +49,7 @@ public interface Writeable {
     /**
      * Setter
      * 
-     * @param key
+     * @param key The String key.
      * @param value
      */
     void setShort(String key, Short value);
@@ -57,7 +57,7 @@ public interface Writeable {
     /**
      * Setter
      * 
-     * @param key
+     * @param key The String key.
      * @param value
      */
     void setLong(String key, Long value);
@@ -65,7 +65,7 @@ public interface Writeable {
     /**
      * Setter
      * 
-     * @param key
+     * @param key The String key.
      * @param value
      */
     void setFloat(String key, Float value);
@@ -73,7 +73,7 @@ public interface Writeable {
     /**
      * Setter
      * 
-     * @param key
+     * @param key The String key.
      * @param value
      */
     void setByteArray(String key, byte[] value);
@@ -81,7 +81,7 @@ public interface Writeable {
     /**
      * Setter
      * 
-     * @param key
+     * @param key The String key.
      * @param value
      */
     void setIntArray(String key, int[] value);
@@ -89,7 +89,7 @@ public interface Writeable {
     /**
      * Setter
      * 
-     * @param key
+     * @param key The String key.
      * @param value
      */
     void setBoolean(String key, Boolean value);
@@ -97,29 +97,31 @@ public interface Writeable {
     /**
      * Save an ItemStack as a compound under a given key
      * 
-     * @param key
+     * @param key The String key.
      * @param item
      */
     void setItemStack(String key, ItemStack item);
 
     /**
-     * Setter
+     * Set a UUID.
      *
-     * @param key
-     * @param value
+     * @param key The String key.
+     * @param value The UUID value.
      */
     void setUUID(String key, UUID value);
 
     /**
-     * @param key Deletes the given Key
+     * Removes the given key and its value.
+     *
+     * @param key The key to delete.
      */
     void removeKey(String key);
 
     /**
-     * The same as addCompound, just with a name that better reflects what it does
+     * Gets an existing compound, or creates it if it
+     * doesn't exist yet.
      * 
-     * @param name
-     * @return
+     * @param name The key of the compound.
      */
     Writeable getOrCreateCompound(String name);
 
@@ -130,7 +132,9 @@ public interface Writeable {
     NBTList<String> getStringList(String name);
 
     /**
-     * @param name
+     * Get the type of a key.
+     *
+     * @param name The String key.
      * @return The type of the given stored key or null
      */
     NBTType getType(String name);

--- a/core/nbt-data-api/src/main/java/de/tr7zw/changeme/nbtapi/data/NBTData.java
+++ b/core/nbt-data-api/src/main/java/de/tr7zw/changeme/nbtapi/data/NBTData.java
@@ -9,7 +9,7 @@ import org.bukkit.World;
 import org.bukkit.plugin.Plugin;
 
 import dev.tr7zw.nbtapi.NBTFile;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 
 public class NBTData {
 
@@ -17,7 +17,7 @@ public class NBTData {
 		try {
 			return new WorldData(world.getWorldFolder());
 		} catch (IOException e) {
-			throw new NbtApiException("Error loading World Data!", e);
+			throw new NBTApiException("Error loading World Data!", e);
 		}
 	}
 
@@ -25,7 +25,7 @@ public class NBTData {
 		try {
 			return new WorldData(worldFolder);
 		} catch (IOException e) {
-			throw new NbtApiException("Error loading World Data!", e);
+			throw new NBTApiException("Error loading World Data!", e);
 		}
 	}
 
@@ -37,7 +37,7 @@ public class NBTData {
 				try {
 					return new PlayerData(playerFile);
 				} catch (IOException e) {
-					throw new NbtApiException("Error loading player data!", e);
+					throw new NBTApiException("Error loading player data!", e);
 				}
 			}
 		}
@@ -50,7 +50,7 @@ public class NBTData {
 			dataFolder.mkdirs();
 			return new NBTFile(new File(dataFolder, uuid.toString() + ".dat"));
 		} catch (IOException e) {
-			throw new NbtApiException("Error getting Player Plugin data!", e);
+			throw new NBTApiException("Error getting Player Plugin data!", e);
 		}
 	}
 
@@ -59,7 +59,7 @@ public class NBTData {
 			plugin.getDataFolder().mkdirs();
 			return new NBTFile(new File(plugin.getDataFolder(), "settings.dat"));
 		} catch (IOException e) {
-			throw new NbtApiException("Error getting Plugin data!", e);
+			throw new NBTApiException("Error getting Plugin data!", e);
 		}
 	}
 

--- a/core/nbt-data-api/src/main/java/de/tr7zw/changeme/nbtapi/data/PlayerData.java
+++ b/core/nbt-data-api/src/main/java/de/tr7zw/changeme/nbtapi/data/PlayerData.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.io.IOException;
 
 import dev.tr7zw.nbtapi.NBTFile;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.Readable;
 
 public class PlayerData {
@@ -27,7 +27,7 @@ public class PlayerData {
 		try {
 			file.save();
 		} catch (IOException e) {
-			throw new NbtApiException("Error when saving level data!", e);
+			throw new NBTApiException("Error when saving level data!", e);
 		}
 	}
 	

--- a/core/nbt-data-api/src/main/java/de/tr7zw/changeme/nbtapi/data/WorldData.java
+++ b/core/nbt-data-api/src/main/java/de/tr7zw/changeme/nbtapi/data/WorldData.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import org.bukkit.util.Vector;
 
 import dev.tr7zw.nbtapi.NBTFile;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.Readable;
 import dev.tr7zw.nbtapi.Writeable;
 
@@ -32,7 +32,7 @@ public class WorldData {
 		try {
 			file.save();
 		} catch (IOException e) {
-			throw new NbtApiException("Error when saving level data!", e);
+			throw new NBTApiException("Error when saving level data!", e);
 		}
 	}
 	

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/GameprofileTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/GameprofileTest.java
@@ -6,7 +6,7 @@ import com.mojang.authlib.GameProfile;
 
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTGameProfile;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class GameprofileTest implements Test {
@@ -19,7 +19,7 @@ public class GameprofileTest implements Test {
 		profile = null;
 		profile = NBTGameProfile.fromNBT(nbt);
 		if (profile == null || !profile.getId().equals(uuid)) {
-			throw new NbtApiException("Error when converting a GameProfile from/to NBT!");
+			throw new NBTApiException("Error when converting a GameProfile from/to NBT!");
 		}
 	}
 

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/NBTFileTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/NBTFileTest.java
@@ -6,8 +6,7 @@ import java.nio.file.Files;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTContainer;
 import de.tr7zw.nbtapi.NBTFile;
-import dev.tr7zw.nbtapi.NbtApiException;
-import dev.tr7zw.nbtapi.Writeable;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.NBTAPI;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
@@ -31,19 +30,19 @@ public class NBTFileTest implements Test {
 		file.save();
 		
 		if(!"wool".equals(block.getString("type"))) {
-			throw new NbtApiException("SubCompounds did not work!");
+			throw new NBTApiException("SubCompounds did not work!");
 		}
 
 		NBTFile fileLoaded = new NBTFile(testFile);
 		if (!fileLoaded.getString("test").equals("test")) {
-			throw new NbtApiException("Wasn't able to load NBT File with the correct content!");
+			throw new NBTApiException("Wasn't able to load NBT File with the correct content!");
 		}
 		Files.deleteIfExists(fileLoaded.getFile().toPath());
 		// String
 		String str = fileLoaded.asNBTString();
 		NBTContainer rebuild = new NBTContainer(str);
 		if (!str.equals(rebuild.asNBTString())) {
-			throw new NbtApiException("Wasn't able to parse NBT from a String!");
+			throw new NBTApiException("Wasn't able to parse NBT from a String!");
 		}
 	}
 

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/blocks/BlockNBTTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/blocks/BlockNBTTest.java
@@ -7,7 +7,7 @@ import org.bukkit.block.Block;
 
 import de.tr7zw.nbtapi.NBTBlock;
 import de.tr7zw.nbtapi.utils.MinecraftVersion;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class BlockNBTTest implements Test {
@@ -24,15 +24,15 @@ public class BlockNBTTest implements Test {
 					NBTBlock comp = new NBTBlock(block);
 					comp.getData().removeKey("Too");
 					if(comp.getData().hasKey("Too")) {
-						throw new NbtApiException("Unable to remove key from Block!");
+						throw new NBTApiException("Unable to remove key from Block!");
 					}
 					comp.getData().setString("Too", "Bar");
 					if (!new NBTBlock(block).getData().getString("Too").equals("Bar")) {
-						throw new NbtApiException("Custom Data did not save to a Block!");
+						throw new NBTApiException("Custom Data did not save to a Block!");
 					}
 				}
 			} catch (Exception ex) {
-				throw new NbtApiException("Wasn't able to use NBTBlocks!", ex);
+				throw new NBTApiException("Wasn't able to use NBTBlocks!", ex);
 			}
 		}
 	}

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/chunks/ChunkNBTPersistentTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/chunks/ChunkNBTPersistentTest.java
@@ -7,7 +7,7 @@ import org.bukkit.World;
 import de.tr7zw.nbtapi.NBTChunk;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.utils.MinecraftVersion;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class ChunkNBTPersistentTest implements Test {
@@ -24,15 +24,15 @@ public class ChunkNBTPersistentTest implements Test {
 					NBTCompound persistentData = comp.getPersistentDataContainer();
 					persistentData.removeKey("Foo");
 					if(persistentData.hasKey("Foo")) {
-						throw new NbtApiException("Unable to remove key from Chunk!");
+						throw new NBTApiException("Unable to remove key from Chunk!");
 					}
 					persistentData.setString("Foo", "Bar");
 					if (!new NBTChunk(chunk).getPersistentDataContainer().getString("Foo").equals("Bar")) {
-						throw new NbtApiException("Custom Data did not save to the Chunk!");
+						throw new NBTApiException("Custom Data did not save to the Chunk!");
 					}
 				}
 			} catch (Exception ex) {
-				throw new NbtApiException("Wasn't able to use NBTChunks!", ex);
+				throw new NBTApiException("Wasn't able to use NBTChunks!", ex);
 			}
 		}
 	}

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/compounds/EqualsTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/compounds/EqualsTest.java
@@ -8,7 +8,7 @@ import org.bukkit.inventory.ItemStack;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTContainer;
 import de.tr7zw.nbtapi.NBTItem;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class EqualsTest implements Test{
@@ -29,13 +29,13 @@ public class EqualsTest implements Test{
 		customData.setString("hello", "world");
 		customData.getStringList("somelist").addAll(Arrays.asList("a", "b", "c"));
 		if(!customData.equals(cont)) {
-			throw new NbtApiException("Compounds did not match! " + customData + " " + cont);
+			throw new NBTApiException("Compounds did not match! " + customData + " " + cont);
 		}
 		
 		// empty test
 		
 		if(!new NBTContainer().equals(new NBTContainer())) {
-		    throw new NbtApiException("Two empty tags did not match!");
+		    throw new NBTApiException("Two empty tags did not match!");
 		}
 		
 		// not equal test
@@ -46,7 +46,7 @@ public class EqualsTest implements Test{
         part2.setString("a", "a");
         part2.setString("b", "a");
         if(part1.equals(part2)) {
-            throw new NbtApiException("Missmatched nbt did match!");
+            throw new NBTApiException("Missmatched nbt did match!");
         }
 	}
 

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/compounds/ForEachTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/compounds/ForEachTest.java
@@ -5,7 +5,7 @@ import java.util.ListIterator;
 import de.tr7zw.nbtapi.NBTCompoundList;
 import de.tr7zw.nbtapi.NBTContainer;
 import de.tr7zw.nbtapi.NBTListCompound;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 /**
@@ -28,7 +28,7 @@ public class ForEachTest implements Test {
             	count++;  
             }
             if(count != compList.size())
-            	throw new NbtApiException("For loop did not get all Entries!");
+            	throw new NBTApiException("For loop did not get all Entries!");
             count = 0;
             ListIterator<NBTListCompound> lit = compList.listIterator();
             while(lit.hasNext()){
@@ -36,14 +36,14 @@ public class ForEachTest implements Test {
             	count++;
             }
             if(count != compList.size())
-            	throw new NbtApiException("ListIterator did not get all Entries!");
+            	throw new NBTApiException("ListIterator did not get all Entries!");
             count = 0;
             while(lit.hasPrevious()){
             	lit.previous();
             	count++;
             }
             if(count != compList.size())
-            	throw new NbtApiException("ListIterator previous did not get all Entries!");
+            	throw new NBTApiException("ListIterator previous did not get all Entries!");
         }
 	}
 

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/compounds/GetterSetterTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/compounds/GetterSetterTest.java
@@ -1,7 +1,7 @@
 package dev.tr7zw.nbtapi.plugin.tests.legacy.compounds;
 
 import de.tr7zw.nbtapi.NBTContainer;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class GetterSetterTest implements Test {
@@ -44,7 +44,7 @@ public class GetterSetterTest implements Test {
 		comp.setByteArray(BYTEARRAY_TEST_KEY, BYTEARRAY_TEST_VALUE);
 
 		if (!comp.hasKey(STRING_TEST_KEY)) {
-			throw new NbtApiException("Wasn't able to check a key! The Item-NBT-API may not work!");
+			throw new NBTApiException("Wasn't able to check a key! The Item-NBT-API may not work!");
 		}
 		if (!(STRING_TEST_VALUE).equals(comp.getString(STRING_TEST_KEY))
 				|| comp.getInteger(INT_TEST_KEY) != INT_TEST_VALUE
@@ -54,7 +54,7 @@ public class GetterSetterTest implements Test {
 				|| comp.getIntArray(INTARRAY_TEST_KEY).length != (INTARRAY_TEST_VALUE).length
 				|| comp.getByteArray(BYTEARRAY_TEST_KEY).length != (BYTEARRAY_TEST_VALUE).length
 				|| !comp.getBoolean(BOOLEAN_TEST_KEY).equals(BOOLEAN_TEST_VALUE)) {
-			throw new NbtApiException("One key does not equal the original value! The Item-NBT-API may not work!");
+			throw new NBTApiException("One key does not equal the original value! The Item-NBT-API may not work!");
 		}
 	}
 

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/compounds/GsonTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/compounds/GsonTest.java
@@ -5,7 +5,7 @@ import org.bukkit.inventory.ItemStack;
 
 import de.tr7zw.nbtapi.NBTItem;
 import de.tr7zw.nbtapi.utils.MinecraftVersion;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class GsonTest implements Test {
@@ -22,23 +22,23 @@ public class GsonTest implements Test {
 			nbtItem.setObject(JSON_TEST_KEY, new SimpleJsonTestObject());
 
 			if (!nbtItem.hasKey(JSON_TEST_KEY)) {
-				throw new NbtApiException(
+				throw new NBTApiException(
 						"Wasn't able to find JSON key! The Item-NBT-API may not work with Json serialization/deserialization!");
 			} else {
 				SimpleJsonTestObject simpleObject = nbtItem.getObject(JSON_TEST_KEY, SimpleJsonTestObject.class);
 				if (simpleObject == null) {
-					throw new NbtApiException(
+					throw new NBTApiException(
 							"Wasn't able to check JSON key! The Item-NBT-API may not work with Json serialization/deserialization!");
 				} else if (!(STRING_TEST_VALUE).equals(simpleObject.getTestString())
 						|| simpleObject.getTestInteger() != INT_TEST_VALUE
 						|| simpleObject.getTestDouble() != DOUBLE_TEST_VALUE
 						|| !simpleObject.isTestBoolean() == BOOLEAN_TEST_VALUE) {
-					throw new NbtApiException(
+					throw new NBTApiException(
 							"One key does not equal the original value in JSON! The Item-NBT-API may not work with Json serialization/deserialization!");
 				}
 			}
 		} catch (Exception ex) {
-			throw new NbtApiException("Exception during Gson check!", ex);
+			throw new NBTApiException("Exception during Gson check!", ex);
 		}
 	}
 

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/compounds/MergeTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/compounds/MergeTest.java
@@ -1,7 +1,7 @@
 package dev.tr7zw.nbtapi.plugin.tests.legacy.compounds;
 
 import de.tr7zw.nbtapi.NBTContainer;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class MergeTest implements Test {
@@ -15,7 +15,7 @@ public class MergeTest implements Test {
 		test2.addCompound("test").setLong("time", System.currentTimeMillis());
 		test1.mergeCompound(test2);
 		if (!test1.getString("test1").equals(test1.getString("test2"))) {
-			throw new NbtApiException("Wasn't able to merge Compounds!");
+			throw new NBTApiException("Wasn't able to merge Compounds!");
 		}
 	}
 

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/compounds/RemovingKeys.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/compounds/RemovingKeys.java
@@ -1,7 +1,7 @@
 package dev.tr7zw.nbtapi.plugin.tests.legacy.compounds;
 
 import de.tr7zw.nbtapi.NBTContainer;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class RemovingKeys implements Test {
@@ -44,7 +44,7 @@ public class RemovingKeys implements Test {
 		comp.setByteArray(BYTEARRAY_TEST_KEY, BYTEARRAY_TEST_VALUE);
 
 		if (comp.getKeys().size() != 10) {
-			throw new NbtApiException("Key amount did not match after setting keys!");
+			throw new NBTApiException("Key amount did not match after setting keys!");
 		}
 
 		comp.setString(STRING_TEST_KEY, null);
@@ -59,7 +59,7 @@ public class RemovingKeys implements Test {
 		comp.setByteArray(BYTEARRAY_TEST_KEY, null);
 
 		if (comp.getKeys().size() != 0) {
-			throw new NbtApiException("Keys where not removed using the setter with null!");
+			throw new NBTApiException("Keys where not removed using the setter with null!");
 		}
 
 	}

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/compounds/StreamTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/compounds/StreamTest.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
 import de.tr7zw.nbtapi.NBTContainer;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class StreamTest implements Test{
@@ -19,7 +19,7 @@ public class StreamTest implements Test{
 		ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
 		NBTContainer container = new NBTContainer(inputStream);
 		if(!container.toString().equals(base.getCompound("sub").toString())) {
-			throw new NbtApiException("Component content did not match! " + base.getCompound("sub") + " " + container);
+			throw new NBTApiException("Component content did not match! " + base.getCompound("sub") + " " + container);
 		}
 	}
 

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/compounds/SubCompoundsTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/compounds/SubCompoundsTest.java
@@ -2,7 +2,7 @@ package dev.tr7zw.nbtapi.plugin.tests.legacy.compounds;
 
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTContainer;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class SubCompoundsTest implements Test {
@@ -27,29 +27,29 @@ public class SubCompoundsTest implements Test {
 		comp.setDouble(DOUBLE_TEST_KEY, DOUBLE_TEST_VALUE * 2);
 
 		if (cont.getCompound("invalide") != null) {
-			throw new NbtApiException("An invalide compound did not return null!");
+			throw new NBTApiException("An invalide compound did not return null!");
 		}
 
 		comp = null;
 
 		comp = cont.getCompound(COMP_TEST_KEY);
 		if (comp == null) {
-			throw new NbtApiException("Wasn't able to get the NBTCompound!");
+			throw new NBTApiException("Wasn't able to get the NBTCompound!");
 		}
 		if (!comp.hasKey(STRING_TEST_KEY)) {
-			throw new NbtApiException("Wasn't able to check a compound key!");
+			throw new NBTApiException("Wasn't able to check a compound key!");
 		}
 		if (!(STRING_TEST_VALUE + "2").equals(comp.getString(STRING_TEST_KEY))
 				|| comp.getInteger(INT_TEST_KEY) != INT_TEST_VALUE * 2
 				|| comp.getDouble(DOUBLE_TEST_KEY) != DOUBLE_TEST_VALUE * 2
 				|| comp.getBoolean(BOOLEAN_TEST_KEY) == BOOLEAN_TEST_VALUE) {
-			throw new NbtApiException("One key does not equal the original compound value!");
+			throw new NBTApiException("One key does not equal the original compound value!");
 		}
 		
 		// Using getOrCreateCompound twice
 		comp.getOrCreateCompound("someName").setString("test", "abc");
 		if(!comp.getOrCreateCompound("someName").getString("test").equals("abc")) {
-			throw new NbtApiException("getOrCreateCompound did not return the same compound!");
+			throw new NBTApiException("getOrCreateCompound did not return the same compound!");
 		}
 	}
 

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/data/WorldDataTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/data/WorldDataTest.java
@@ -7,7 +7,7 @@ import org.bukkit.World;
 
 import de.tr7zw.changeme.nbtapi.data.NBTData;
 import de.tr7zw.changeme.nbtapi.data.WorldData;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class WorldDataTest implements Test{
@@ -17,7 +17,7 @@ public class WorldDataTest implements Test{
 		for(World world : Bukkit.getWorlds()){
 			if(!new File(world.getWorldFolder(), "level.dat").exists())continue;
 			WorldData data = NBTData.getWorldData(world);
-			if(data.getWorldName() == null || data.getSpawnPosition() == null)throw new NbtApiException("Got Null");
+			if(data.getWorldName() == null || data.getSpawnPosition() == null)throw new NBTApiException("Got Null");
 		}
 	}
 

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/entities/EntityCustomNbtPersistentTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/entities/EntityCustomNbtPersistentTest.java
@@ -9,7 +9,7 @@ import org.bukkit.entity.Monster;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTEntity;
 import de.tr7zw.nbtapi.utils.MinecraftVersion;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class EntityCustomNbtPersistentTest implements Test {
@@ -27,13 +27,13 @@ public class EntityCustomNbtPersistentTest implements Test {
 					comp.setString("Hello", "World");
 					NBTEntity nbtent = new NBTEntity(ent);
 					if (!nbtent.toString().contains("Hello:\"World\"")) {
-						throw new NbtApiException("Custom Data did not save to the Entity!");
+						throw new NBTApiException("Custom Data did not save to the Entity!");
 					}
 					comp.removeKey("Hello");
 
 				}
 			} catch (Exception ex) {
-				throw new NbtApiException("Wasn't able to use NBTEntities!", ex);
+				throw new NBTApiException("Wasn't able to use NBTEntities!", ex);
 			}
 		}
 	}

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/entities/EntityTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/entities/EntityTest.java
@@ -6,7 +6,7 @@ import org.bukkit.entity.Animals;
 import org.bukkit.entity.Monster;
 
 import de.tr7zw.nbtapi.NBTEntity;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class EntityTest implements Test {
@@ -22,7 +22,7 @@ public class EntityTest implements Test {
 					nbte.setString("INVALIDEKEY", "test");
 				}
 			} catch (Exception ex) {
-				throw new NbtApiException("Wasn't able to use NBTEntities!", ex);
+				throw new NBTApiException("Wasn't able to use NBTEntities!", ex);
 			}
 		}
 	}

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/injector/EntityCustomNbtInjectorTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/injector/EntityCustomNbtInjectorTest.java
@@ -9,7 +9,7 @@ import org.bukkit.entity.Monster;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTEntity;
 import de.tr7zw.nbtinjector.NBTInjector;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class EntityCustomNbtInjectorTest implements Test {
@@ -27,13 +27,13 @@ public class EntityCustomNbtInjectorTest implements Test {
 					comp.setString("Hello", "World");
 					NBTEntity nbtent = new NBTEntity(ent);
 					if (!nbtent.toString().contains("__extraData:{Hello:\"World\"}")) {
-						throw new NbtApiException("Custom Data did not save to the Entity!");
+						throw new NBTApiException("Custom Data did not save to the Entity!");
 					}
 					comp.removeKey("Hello");
 
 				}
 			} catch (Exception ex) {
-				throw new NbtApiException("Wasn't able to use NBTEntities!", ex);
+				throw new NBTApiException("Wasn't able to use NBTEntities!", ex);
 			}
 		}
 	}

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/injector/MergeTileSubCompoundTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/injector/MergeTileSubCompoundTest.java
@@ -8,7 +8,7 @@ import org.bukkit.block.Block;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTContainer;
 import de.tr7zw.nbtinjector.NBTInjector;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class MergeTileSubCompoundTest implements Test {
@@ -34,11 +34,11 @@ public class MergeTileSubCompoundTest implements Test {
 					}
 					block.setType(Material.AIR);
 					if(failed) {
-						throw new NbtApiException("Data was not correct! " + cont);
+						throw new NBTApiException("Data was not correct! " + cont);
 					}
 				}
 			} catch (Exception ex) {
-				throw new NbtApiException("Wasn't able to use NBTTiles!", ex);
+				throw new NBTApiException("Wasn't able to use NBTTiles!", ex);
 			}
 		}
 	}

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/injector/SpawnEntityCustomNbtInjectorTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/injector/SpawnEntityCustomNbtInjectorTest.java
@@ -9,7 +9,7 @@ import org.bukkit.entity.EntityType;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTEntity;
 import de.tr7zw.nbtinjector.NBTInjector;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class SpawnEntityCustomNbtInjectorTest implements Test {
@@ -27,13 +27,13 @@ public class SpawnEntityCustomNbtInjectorTest implements Test {
 				comp.setString("Hello", "World");
 				NBTEntity nbtent = new NBTEntity(entity);
 				if (!nbtent.toString().contains("__extraData:{Hello:\"World\"}")) {
-					throw new NbtApiException("Custom Data did not save to the Entity!");
+					throw new NBTApiException("Custom Data did not save to the Entity!");
 				}
 				comp.removeKey("Hello");
 				entity.remove();
 
 			} catch (Exception ex) {
-				throw new NbtApiException("Wasn't able to use NBTEntities!", ex);
+				throw new NBTApiException("Wasn't able to use NBTEntities!", ex);
 			}
 		}
 	}

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/injector/TilesCustomNBTInjectorTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/injector/TilesCustomNBTInjectorTest.java
@@ -8,7 +8,7 @@ import org.bukkit.block.Block;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTTileEntity;
 import de.tr7zw.nbtinjector.NBTInjector;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class TilesCustomNBTInjectorTest implements Test {
@@ -27,12 +27,12 @@ public class TilesCustomNBTInjectorTest implements Test {
 					comp.setString("Foo", "Bar");
 					if (!new NBTTileEntity(block.getState()).toString().contains("__extraData:{Foo:\"Bar\"}")) {
 						block.setType(Material.AIR);
-						throw new NbtApiException("Custom Data did not save to the Tile!");
+						throw new NBTApiException("Custom Data did not save to the Tile!");
 					}
 					block.setType(Material.AIR);
 				}
 			} catch (Exception ex) {
-				throw new NbtApiException("Wasn't able to use NBTTiles!", ex);
+				throw new NBTApiException("Wasn't able to use NBTTiles!", ex);
 			}
 		}
 	}

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/items/DirectApplyTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/items/DirectApplyTest.java
@@ -4,7 +4,7 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 import de.tr7zw.nbtapi.NBTItem;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class DirectApplyTest implements Test{
@@ -15,7 +15,7 @@ public class DirectApplyTest implements Test{
 		NBTItem nbti = new NBTItem(baseItem, true);
 		nbti.setString("SomeKey", "SomeValue");
 		if(!baseItem.equals(nbti.getItem()) || !new NBTItem(baseItem).hasKey("SomeKey")) {
-			throw new NbtApiException("The item's where not equal!");
+			throw new NBTApiException("The item's where not equal!");
 		}
 	}
 

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/items/EmptyItemTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/items/EmptyItemTest.java
@@ -4,7 +4,7 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 import de.tr7zw.nbtapi.NBTItem;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class EmptyItemTest implements Test {
@@ -14,7 +14,7 @@ public class EmptyItemTest implements Test {
 		ItemStack item = new ItemStack(Material.STONE);
 		NBTItem nbti = new NBTItem(item);
 		if (nbti.getBoolean("test") == null || nbti.getString("test") == null)
-			throw new NbtApiException("Getters return null instead of the default value");
+			throw new NBTApiException("Getters return null instead of the default value");
 
 		try {
 			Material barrel = Material.valueOf("BARREL");

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/items/ItemConvertionTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/items/ItemConvertionTest.java
@@ -8,7 +8,7 @@ import com.google.common.collect.Lists;
 
 import de.tr7zw.nbtapi.NBTContainer;
 import de.tr7zw.nbtapi.NBTItem;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class ItemConvertionTest implements Test {
@@ -21,15 +21,15 @@ public class ItemConvertionTest implements Test {
 		item.setItemMeta(meta);
 		String nbt = NBTItem.convertItemtoNBT(item).toString();
 		if (!nbt.contains("Firest Line") || !nbt.contains("Second Line"))
-			throw new NbtApiException("The Item nbt '" + nbt + "' didn't contain the lore");
+			throw new NBTApiException("The Item nbt '" + nbt + "' didn't contain the lore");
 		ItemStack rebuild = NBTItem.convertNBTtoItem(new NBTContainer(nbt));
 		if (!item.isSimilar(rebuild))
-			throw new NbtApiException("Rebuilt item did not match the original!");
+			throw new NBTApiException("Rebuilt item did not match the original!");
 		
 		NBTContainer cont = new NBTContainer();
 		cont.setItemStack("testItem", item);
 		if(!cont.getItemStack("testItem").isSimilar(item))
-			throw new NbtApiException("Rebuilt item did not match the original!");
+			throw new NBTApiException("Rebuilt item did not match the original!");
 	}
 
 }

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/items/ItemMergingTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/items/ItemMergingTest.java
@@ -5,7 +5,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 
 import de.tr7zw.nbtapi.NBTItem;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class ItemMergingTest implements Test {
@@ -24,33 +24,33 @@ public class ItemMergingTest implements Test {
 
 		nbti.mergeCustomNBT(item);
 		if (!new NBTItem(item).hasKey("test"))
-			throw new NbtApiException("Couldn't merge custom NBT tag!");
+			throw new NBTApiException("Couldn't merge custom NBT tag!");
 		if ("New Author".equals(new NBTItem(item).getString("author")))
-			throw new NbtApiException("Vanilla NBT tag was merged when shouldn't!");
+			throw new NBTApiException("Vanilla NBT tag was merged when shouldn't!");
 
 		nbti.setString("test", "New Value");
 		nbti.mergeNBT(item);
 		if (!"New Author".equals(new NBTItem(item).getString("author")) || !"New Value".equals(new NBTItem(item).getString("test")))
-			throw new NbtApiException("Couldn't replace NBT tag while merging!");
+			throw new NBTApiException("Couldn't replace NBT tag while merging!");
 
 		ItemStack test = new ItemStack(Material.WRITTEN_BOOK);
 		nbti.applyNBT(test);
 		if (!item.isSimilar(test))
-			throw new NbtApiException("ItemStacks didn't match! " + new NBTItem(item) + " " + new NBTItem(test));
+			throw new NBTApiException("ItemStacks didn't match! " + new NBTItem(item) + " " + new NBTItem(test));
 
 		test = new ItemStack(Material.STONE);
 		nbti.applyNBT(test);
 		if (!nbti.hasKey("test"))
-			throw new NbtApiException("Couldn't merge custom NBT tag!");
+			throw new NBTApiException("Couldn't merge custom NBT tag!");
 		if (!item.getItemMeta().getDisplayName().equals(test.getItemMeta().getDisplayName()))
-			throw new NbtApiException("Couldn't merge vanilla NBT tag!");
+			throw new NBTApiException("Couldn't merge vanilla NBT tag!");
 
 		nbti.setBoolean("remove", true);
 		nbti.clearCustomNBT();
 		if (nbti.hasKey("remove"))
-			throw new NbtApiException("Couldn't clear custom NBT tags!");
+			throw new NBTApiException("Couldn't clear custom NBT tags!");
 		if (!nbti.hasKey("author"))
-			throw new NbtApiException("Vanilla tag was removed!");
+			throw new NBTApiException("Vanilla tag was removed!");
 	}
 
 }

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/tiles/TileTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/tiles/TileTest.java
@@ -7,7 +7,7 @@ import org.bukkit.block.Block;
 
 import de.tr7zw.nbtapi.NBTTileEntity;
 import de.tr7zw.nbtapi.utils.MinecraftVersion;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class TileTest implements Test {
@@ -24,17 +24,17 @@ public class TileTest implements Test {
 					NBTTileEntity tile = new NBTTileEntity(block.getState());
 					if(tile.getInteger("y") != 254) {
 						block.setType(Material.AIR);
-						throw new NbtApiException("The Tile Y pos wasn't correct!");
+						throw new NBTApiException("The Tile Y pos wasn't correct!");
 					}
 					tile.setString("Lock", "test");
 					if (MinecraftVersion.isAtLeastVersion(MinecraftVersion.MC1_8_R3) && !tile.hasKey("Lock") && !"test".equals(tile.getString("test"))) {
 						block.setType(Material.AIR);
-						throw new NbtApiException("The Lock wasn't successfully set.");
+						throw new NBTApiException("The Lock wasn't successfully set.");
 					}
 					block.setType(Material.AIR);
 				}
 			} catch (Exception ex) {
-				throw new NbtApiException("Wasn't able to use NBTTiles!", ex);
+				throw new NBTApiException("Wasn't able to use NBTTiles!", ex);
 			}
 		}
 	}

--- a/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/tiles/TilesCustomNBTPersistentTest.java
+++ b/spigot/nbt-api-plugin/src/main/java/dev/tr7zw/nbtapi/plugin/tests/legacy/tiles/TilesCustomNBTPersistentTest.java
@@ -8,7 +8,7 @@ import org.bukkit.block.Block;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTTileEntity;
 import de.tr7zw.nbtapi.utils.MinecraftVersion;
-import dev.tr7zw.nbtapi.NbtApiException;
+import dev.tr7zw.nbtapi.NBTApiException;
 import dev.tr7zw.nbtapi.plugin.tests.Test;
 
 public class TilesCustomNBTPersistentTest implements Test {
@@ -28,12 +28,12 @@ public class TilesCustomNBTPersistentTest implements Test {
 					persistentData.setString("Foo", "Bar");
 					if (!new NBTTileEntity(block.getState()).getPersistentDataContainer().getString("Foo").equals("Bar")) {
 						block.setType(Material.AIR);
-						throw new NbtApiException("Custom Data did not save to the Tile!");
+						throw new NBTApiException("Custom Data did not save to the Tile!");
 					}
 					block.setType(Material.AIR);
 				}
 			} catch (Exception ex) {
-				throw new NbtApiException("Wasn't able to use NBTTiles!", ex);
+				throw new NBTApiException("Wasn't able to use NBTTiles!", ex);
 			}
 		}
 	}


### PR DESCRIPTION
- Renames NbtApiException to NBTApiException to be consistent with everything else.
- Removes a unnecessary loop in NBTType.
- Adds/Fixes a lot of javadocs.