### PR TITLE
Fix: Add missing NBTType.NBTTagLongArray

### DIFF
--- a/core/nbt-api/src/main/java/dev/tr7zw/nbtapi/NBTType.java
+++ b/core/nbt-api/src/main/java/dev/tr7zw/nbtapi/NBTType.java
@@ -7,30 +7,25 @@ package dev.tr7zw.nbtapi;
  *
  */
 public enum NBTType {
-	NBTTagEnd(0),
-    NBTTagByte(1),
-	NBTTagShort(2), 
-	NBTTagInt(3), 
-	NBTTagLong(4), 
-	NBTTagFloat(5), 
-	NBTTagDouble(6),
-	NBTTagByteArray(7), 
-	NBTTagIntArray(11), 
-	NBTTagString(8), 
-	NBTTagList(9), 
-	NBTTagCompound(10);
-
-	NBTType(int i) {
-		id = i;
-	}
-
-	private final int id;
+	NBTTagEnd(),
+	NBTTagByte(),
+	NBTTagShort(),
+	NBTTagInt(),
+	NBTTagLong(),
+	NBTTagFloat(),
+	NBTTagDouble(),
+	NBTTagByteArray(),
+	NBTTagString(),
+	NBTTagList(),
+	NBTTagCompound(),
+	NBTTagIntArray(),
+	NBTTagLongArray();
 
 	/**
 	 * @return Id used by Minecraft internally
 	 */
 	public int getId() {
-		return id;
+		return ordinal();
 	}
 
 	/**


### PR DESCRIPTION
#131 actually broke NBTType, but this fixes that, adds the missing `NBTTagLongArray` enum and also removes the unnecessary `id` field.