### PR TITLE
Add getVector/setVector to Spigot implementation

### DIFF
--- a/spigot/nbt-api-spigot/src/main/java/dev/tr7zw/nbtapi/spigot/impl/NBTCompoundAccessorImpl.java
+++ b/spigot/nbt-api-spigot/src/main/java/dev/tr7zw/nbtapi/spigot/impl/NBTCompoundAccessorImpl.java
@@ -3,10 +3,13 @@ package dev.tr7zw.nbtapi.spigot.impl;
 import java.util.Set;
 import java.util.UUID;
 
+import dev.tr7zw.nbtapi.NBTCompound;
 import dev.tr7zw.nbtapi.NBTCompoundAccessor;
 import dev.tr7zw.nbtapi.NBTList;
 import dev.tr7zw.nbtapi.NBTType;
 import dev.tr7zw.nbtapi.Readable;
+
+import org.bukkit.util.Vector;
 
 public class NBTCompoundAccessorImpl implements NBTCompoundAccessor {
 
@@ -136,4 +139,8 @@ public class NBTCompoundAccessorImpl implements NBTCompoundAccessor {
         return false;
     }
 
+    public Vector getVector(String name) {
+        Readable compound = getCompound(name);
+        return new Vector(compound.getDouble("x"), compound.getDouble("y"), compound.getDouble("z"));
+    }
 }

--- a/spigot/nbt-api-spigot/src/main/java/dev/tr7zw/nbtapi/spigot/impl/NBTCompoundImpl.java
+++ b/spigot/nbt-api-spigot/src/main/java/dev/tr7zw/nbtapi/spigot/impl/NBTCompoundImpl.java
@@ -5,6 +5,8 @@ import java.util.UUID;
 import dev.tr7zw.nbtapi.NBTCompound;
 import dev.tr7zw.nbtapi.Readable;
 
+import org.bukkit.util.Vector;
+
 public class NBTCompoundImpl extends NBTCompoundAccessorImpl implements NBTCompound{
 
     @Override
@@ -91,4 +93,11 @@ public class NBTCompoundImpl extends NBTCompoundAccessorImpl implements NBTCompo
         return null;
     }
 
+    public NBTCompound setVector(String name, Vector vector) {
+        NBTCompound compound = getOrCreateCompound(name);
+        compound.setDouble("x", vector.getX());
+        compound.setDouble("y", vector.getY());
+        compound.setDouble("z", vector.getZ());
+        return this;
+    }
 }


### PR DESCRIPTION
I feel like this is a good addition to the API for 3.0. As there is no general Vector type in Java, a Spigot implementation should be enough for now, maybe something can be figured out in the future.
Also might be nice to backport this to 2.8?