### PR TITLE
Add: 1.18.2 support

### DIFF
--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/utils/MinecraftVersion.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/utils/MinecraftVersion.java
@@ -17,7 +17,7 @@ import org.bukkit.Bukkit;
 public enum MinecraftVersion {
 	UNKNOWN(Integer.MAX_VALUE), // Use the newest known mappings
 	MC1_7_R4(174), MC1_8_R3(183), MC1_9_R1(191), MC1_9_R2(192), MC1_10_R1(1101), MC1_11_R1(1111), MC1_12_R1(1121),
-	MC1_13_R1(1131), MC1_13_R2(1132), MC1_14_R1(1141), MC1_15_R1(1151), MC1_16_R1(1161), MC1_16_R2(1162), MC1_16_R3(1163), MC1_17_R1(1171), MC1_18_R1(1181, true);
+	MC1_13_R1(1131), MC1_13_R2(1132), MC1_14_R1(1141), MC1_15_R1(1151), MC1_16_R1(1161), MC1_16_R2(1162), MC1_16_R3(1163), MC1_17_R1(1171), MC1_18_R1(1181, true), MC1_18_R2(1182, true);
 
 	private static MinecraftVersion version;
 	private static Boolean hasGsonSupport;


### PR DESCRIPTION
Fairly simple update lol. I quickly ran it on my server and all of it still seems to work fine. This fixes the issue because otherwise it doesn't find a corresponding `MinecraftVersion` enum value and just uses the last available, in our case that's `MC1_18_R1`. This is, indeed, a more temporary fix but does it for now.