### PR TITLE
Added a null check to NBTCompound#getItemStack

### DIFF
--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTCompound.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTCompound.java
@@ -471,6 +471,7 @@ public class NBTCompound {
 		try {
 			readLock.lock();
 			NBTCompound comp = getCompound(key);
+			if (comp == null) return null; // NBTReflectionUtil#convertNBTCompoundtoNMSItem doesn't accept null
 			return NBTItem.convertNBTtoItem(comp);
 		} finally {
 			readLock.unlock();


### PR DESCRIPTION
Since `NBTReflectionUtil#convertNBTCompoundtoNMSItem` doesn't accept null (due to the second line of the method calling `NBTCompound#getCompound`), I added a null check to prevent a NbtApiException caused by a NPE.