### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -9,6 +9,7 @@ permissions:
   contents: write
 jobs:
   javadoc:
+    if: ${{ github.repository_owner == 'tr7zw' }}
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -13,26 +13,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        distribution: zulu
+        java-version: 8
     - name: Build with Maven
       run: mvn package
     - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4.3.3
+      uses: JamesIves/github-pages-deploy-action@v4.4.1
       with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh-pages
-        CLEAN: false
-        FOLDER: item-nbt-api/target/apidocs
+        token: ${{ secrets.GITHUB_TOKEN }}
+        branch: gh-pages
+        clean: false
+        folder: item-nbt-api/target/apidocs
         target-folder: v2-api
     - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4.3.3
+      uses: JamesIves/github-pages-deploy-action@v4.4.1
       with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh-pages
-        CLEAN: false
-        FOLDER: item-nbt-plugin/target/apidocs
+        token: ${{ secrets.GITHUB_TOKEN }}
+        branch: gh-pages
+        clean: false
+        folder: item-nbt-plugin/target/apidocs
         target-folder: v2-plugin

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,10 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        distribution: zulu
+        java-version: 8
     - name: Build with Maven
       run: mvn --file pom.xml

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -30,4 +30,4 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add .
-        git commit -m "Add changes" && git push
+        git diff-index --quiet HEAD || (git commit -m "Add changes" && git push)

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -14,11 +14,11 @@ jobs:
 
     steps:
     - name: Checkout base code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: base-code
     - name: Checkout wiki code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: ${{github.repository}}.wiki
         path: wiki

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -9,6 +9,7 @@ permissions:
   contents: write
 jobs:
   wiki:
+    if: ${{ github.repository_owner == 'tr7zw' }}
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
- Updated actions to up-to-date ones (& fixed warnings).
  - `zulu` was the default distribution for `setup-java` action (it is a mandatory property now).
- Fixed wiki failing with no changes by checking the diff first.
- Added extra check for wiki & javadoc deployment workflows to not run on forks.