### PR TITLE
Fix NPE hiding the actual error when passing null object

### DIFF
--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/utils/nmsmappings/ReflectionMethod.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/utils/nmsmappings/ReflectionMethod.java
@@ -355,7 +355,7 @@ public enum ReflectionMethod {
             return method.invoke(target, args);
         } catch (Exception ex) {
             throw new NbtApiException("Error while calling the method '" + methodName + "', loaded: " + loaded
-                    + ", Enum: " + this + " Passed Class: " + target.getClass(), ex);
+                    + ", Enum: " + this + ", Passed Class: " + (target == null ? "null" : target.getClass()), ex);
         }
     }
 


### PR DESCRIPTION
Some of the NBT-API's methods pass `null` object to this method, e.g.:
https://github.com/tr7zw/Item-NBT-API/blob/45504d09f0c57b5d3c887a6a14df656275f7ae93/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTReflectionUtil.java#L73
If some error occurs it gets ommited due to the newly raised NPE.
This commit prevents that NPE.