### PR TITLE
Fix StackOverflowError when merging ReadableNBT

### DIFF
--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTCompound.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTCompound.java
@@ -96,7 +96,7 @@ public class NBTCompound implements ReadWriteNBT {
     @Override
     public void mergeCompound(ReadableNBT comp) {
         if (comp instanceof NBTCompound) {
-            mergeCompound(comp);
+            mergeCompound((NBTCompound) comp);
         } else {
             throw new NbtApiException("Unknown NBT object: " + comp);
         }


### PR DESCRIPTION
Fix StackOverflowError by casting the ReadableNBT object to a NBTCompound