### PR TITLE
Fix Wiki repository url for maven and gradle.

### DIFF
--- a/wiki/Using-Gradle.md
+++ b/wiki/Using-Gradle.md
@@ -11,7 +11,7 @@ repositories {
     ...
     maven {
         name = "CodeMC"
-        url = uri("https://repo.codemc.org/repository/maven-public/")
+        url = uri("https://repo.codemc.io/repository/maven-public/")
     }
     ...
 }
@@ -46,7 +46,7 @@ repositories {
     ...
     maven {
         name = "CodeMC"
-        url = uri("https://repo.codemc.org/repository/maven-public/")
+        url = uri("https://repo.codemc.io/repository/maven-public/")
     }
     ...
 }

--- a/wiki/Using-Maven.md
+++ b/wiki/Using-Maven.md
@@ -15,7 +15,7 @@ Add the following Entries to your pom at the correct location:
 <!-- CodeMC -->
 <repository>
 <id>codemc-repo</id>
-<url>https://repo.codemc.org/repository/maven-public/</url>
+<url>https://repo.codemc.io/repository/maven-public/</url>
 <layout>default</layout>
 </repository>
 ...
@@ -42,7 +42,7 @@ Add the following Entries to your pom at the correct location:
 <!-- CodeMC -->
 <repository>
 <id>codemc-repo</id>
-<url>https://repo.codemc.org/repository/maven-public/</url>
+<url>https://repo.codemc.io/repository/maven-public/</url>
 <layout>default</layout>
 </repository>
 ...


### PR DESCRIPTION
I recognized (it just cost me 1 hour lol) that the url of the codemc repository is wrong. Its .io and not .org.
(.org does not work anymore)

