### PR TITLE
add honorable plugin list mentions

### DIFF
--- a/wiki/Plugins.md
+++ b/wiki/Plugins.md
@@ -1,0 +1,8 @@
+## List of some plugins on Github that utilize NBTAPI
+Want your plugin added to this list? Submit a PR editing this file located in `~/wiki/Plugins.md`!
+
+- [IllegalStack](https://github.com/dniym/IllegalStack)
+- [Prison](https://github.com/PrisonTeam/Prison)
+- [CommandAPI](https://github.com/JorelAli/CommandAPI)
+- [SkBee](https://github.com/ShaneBeee/SkBee/)
+- [Monumenta](https://github.com/TeamMonumenta/monumenta-plugins-public/)


### PR DESCRIPTION
New developers using this API can use existing plugins as reference to help them make their own plugin.