### PR TITLE
Fix Folia detection and NBT#modify for tile entities

### DIFF
--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBT.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBT.java
@@ -279,7 +279,7 @@ public class NBT {
         NBTTileEntity blockEnt = new NBTTileEntity(blockState);
         NBTContainer cont = new NBTContainer(blockEnt.getCompound());
         T ret = function.apply(cont);
-        blockEnt.setCompound(cont);
+        blockEnt.setCompound(cont.getCompound());
         if (ret instanceof ReadableNBT || ret instanceof ReadableNBTList<?>) {
             throw new NbtApiException("Tried returning part of the NBT to outside of the NBT scope!");
         }
@@ -300,7 +300,7 @@ public class NBT {
         NBTTileEntity blockEnt = new NBTTileEntity(blockState);
         NBTContainer cont = new NBTContainer(blockEnt.getCompound());
         consumer.accept(cont);
-        blockEnt.setCompound(cont);
+        blockEnt.setCompound(cont.getCompound());
         blockEnt.setClosed();
     }
 

--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBT.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBT.java
@@ -154,7 +154,7 @@ public class NBT {
     }
 
     /**
-     * It takes an block entity and a function that takes a ReadableNBT and returns
+     * It takes a block entity and a function that takes a ReadableNBT and returns
      * a generic type T, and returns the result of the function, applied to the
      * block entities persistent data container
      * 

--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTBlock.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTBlock.java
@@ -12,7 +12,7 @@ import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
  * instead!
  * 
  * - The data is really just on the location. If the block gets
- * broken/changed/explodes/moved etc, the data is still on that location!
+ * broken/changed/exploded/moved etc., the data is still on that location!
  * 
  * @author tr7zw
  *

--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTFile.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTFile.java
@@ -18,7 +18,7 @@ public class NBTFile extends NBTCompound {
     private Object nbt;
 
     /**
-     * Creates a NBTFile that uses @param file to store it's data. If this file
+     * Creates a NBTFile that uses @param file to store its data. If this file
      * exists, the data will be loaded.
      * 
      * @param file

--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTItem.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTItem.java
@@ -330,7 +330,7 @@ public class NBTItem extends NBTCompound implements ReadWriteItemNBT {
 
     /**
      * Helper method that converts {@link ItemStack}[] to {@link NBTContainer} with
-     * all it data like Material, Damage, Amount and Tags. This is a custom
+     * all its data like Material, Damage, Amount and Tags. This is a custom
      * implementation and won't work with vanilla code(Shulker content etc).
      * 
      * @param items
@@ -355,7 +355,7 @@ public class NBTItem extends NBTCompound implements ReadWriteItemNBT {
     /**
      * Helper method to do the inverse of "convertItemArraytoNBT". Creates an
      * {@link ItemStack}[] using the {@link NBTCompound}. This is a custom
-     * implementation and won't work with vanilla code(Shulker content etc).
+     * implementation and won't work with vanilla code (Shulker content, etc.).
      * 
      * Will return null for invalid data. Empty slots in the array are filled with
      * AIR Stacks!

--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/utils/MinecraftVersion.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/utils/MinecraftVersion.java
@@ -246,7 +246,7 @@ public enum MinecraftVersion {
         }
         try {
             logger.info("[NBTAPI] Found Folia: "
-                    + Class.forName("io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler"));
+                    + Class.forName("io.papermc.paper.threadedregions.RegionizedServer"));
             isFoliaPresent = true;
         } catch (Exception ex) {
             isFoliaPresent = false;


### PR DESCRIPTION
- Fixed an error when using `NBT#modify(BlockState)` due to using NBT API's compound instead of NMS one.
- Fixed modern Paper incorrectly recognized as Folia (Paper now includes that old class for easier compatibility with Folia).
- Some minor javadoc corrections.