### PR TITLE
Prevent chunk loading during tile entity tests

### DIFF
--- a/item-nbt-plugin/src/main/java/de/tr7zw/nbtapi/plugin/tests/tiles/TileTest.java
+++ b/item-nbt-plugin/src/main/java/de/tr7zw/nbtapi/plugin/tests/tiles/TileTest.java
@@ -22,7 +22,7 @@ public class TileTest implements Test {
             try {
                 Block block = world.getBlockAt(world.getSpawnLocation().getBlockX(), 254,
                         world.getSpawnLocation().getBlockZ());
-                if (block.getChunk().isLoaded() && block.getType() == Material.AIR) {
+                if (world.isChunkLoaded(block.getX() >> 4, block.getZ() >> 4) && block.getType() == Material.AIR) {
                     block.setType(Material.CHEST);
                     NBTTileEntity tile = new NBTTileEntity(block.getState());
                     if (!MinecraftVersion.isNewerThan(MinecraftVersion.MC1_17_R1)) {

--- a/item-nbt-plugin/src/main/java/de/tr7zw/nbtapi/plugin/tests/tiles/TilesCustomNBTPersistentTest.java
+++ b/item-nbt-plugin/src/main/java/de/tr7zw/nbtapi/plugin/tests/tiles/TilesCustomNBTPersistentTest.java
@@ -25,7 +25,7 @@ public class TilesCustomNBTPersistentTest implements Test {
             try {
                 Block block = world.getBlockAt(world.getSpawnLocation().getBlockX(), 250,
                         world.getSpawnLocation().getBlockZ());
-                if (block.getType() == Material.AIR) {
+                if (world.isChunkLoaded(block.getX() >> 4, block.getZ() >> 4) && block.getType() == Material.AIR) {
                     block.setType(Material.CHEST);
                     NBTTileEntity comp = new NBTTileEntity(block.getState());
                     NBTCompound persistentData = comp.getPersistentDataContainer();


### PR DESCRIPTION
`block.getChunk().isLoaded()` was loading the chunk and persistent tile nbt test was missing the check.