### PR TITLE
Add EvenMoreFish to Plugins.md

### DIFF
--- a/wiki/Plugins.md
+++ b/wiki/Plugins.md
@@ -2,10 +2,11 @@
 
 - [IllegalStack](https://github.com/dniym/IllegalStack)
 - [Prison](https://github.com/PrisonTeam/Prison)
-- [CommandAPI](https://github.com/JorelAli/CommandAPI)
+- [CommandAPI](https://github.com/CommandAPI/CommandAPI)
 - [SkBee](https://github.com/ShaneBeee/SkBee/)
 - [Monumenta](https://github.com/TeamMonumenta/monumenta-plugins-public/)
 - [SummonFriendlyMobs](https://github.com/ArmyFury/SummonFriendlyMobs)
+- [EvenMoreFish](https://github.com/Oheers/EvenMoreFish)
 
 ___
 


### PR DESCRIPTION
Adds EvenMoreFish to the Plugins.md file.

Also changes CommandAPI's URL to its new location, the [CommandAPI](https://github.com/CommandAPI) org.