### PR TITLE
Update wiki

### DIFF
--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -21,6 +21,4 @@ The experimental NBTInjector became unsupported since Minecraft 1.14 and was rem
 
 NBTInjector is incompatible with reloads and may break things, and thus is not recommended.
 
-If you're using Minecraft 1.14+, you should switch to the persistent storage API instead.
-
-In versions prior to 1.14, you may use a workaround like storing data inside an item's nbt that the entity is wearing (e.g. having a button in mob's helmet, and storing data on that button).
+See [this wiki section](https://github.com/tr7zw/Item-NBT-API/wiki/Using-the-NBT-API#accessing-custom-data) on how to handle custom entity nbt data without NBTInjector.

--- a/wiki/Using-Gradle.md
+++ b/wiki/Using-Gradle.md
@@ -30,6 +30,17 @@ Add the API as dependency to your ``plugin.yml``:
 depend: [NBTAPI]
 ```
 
+Or, if you are using ``paper-plugin.yml``:
+
+```yml
+dependencies:
+  server:
+    NBTAPI:
+      load: BEFORE
+      required: true
+      join-classpath: true
+```
+
 # Option 2) Shading the NBT-API into your plugin
 
 To include NBT-API directly in your plugin, you can use the [Gradle Shadow Plugin](https://gradleup.com/shadow/).

--- a/wiki/Using-Gradle.md
+++ b/wiki/Using-Gradle.md
@@ -32,17 +32,17 @@ depend: [NBTAPI]
 
 # Option 2) Shading the NBT-API into your plugin
 
-To include NBT-API directly in your plugin, you can use the gradle shadow plugin.
+To include NBT-API directly in your plugin, you can use the [Gradle Shadow Plugin](https://gradleup.com/shadow/).
 
 Add the plugin to the build configuration, as shown here:
 
 ```groovy
 plugins {
-    id("com.github.johnrengelman.shadow") version "VERSION"
+    id("com.gradleup.shadow") version "VERSION"
 }
 ```
 
-The latest version of the shadow plugin can be found [here](https://github.com/johnrengelman/shadow/releases).
+The latest version of the shadow plugin can be found [here](https://plugins.gradle.org/plugin/com.gradleup.shadow).
 
 Add NBT-API to your dependencies:
 

--- a/wiki/Using-Maven.md
+++ b/wiki/Using-Maven.md
@@ -37,6 +37,17 @@ Add the API as dependency to your ``plugin.yml``:
 depend: [NBTAPI]
 ```
 
+Or, if you are using ``paper-plugin.yml``:
+
+```yml
+dependencies:
+  server:
+    NBTAPI:
+      load: BEFORE
+      required: true
+      join-classpath: true
+```
+
 # Option 2) Shading the NBT-API into your plugin
 
 To include NBT-API directly in your plugin, you can use the maven shade plugin.

--- a/wiki/Using-the-NBT-API.md
+++ b/wiki/Using-the-NBT-API.md
@@ -243,7 +243,12 @@ NBT.modify(entity, nbt -> {
 
 #### Accessing custom data
 
-For reading/storing custom data on (block-)entities, you should use methods that end with PersistentData.
+> [!WARNING]
+> Persistent data storage for custom (block-)entity nbt is only available in 1.14+.
+>
+> If you need to support versions below that, for entities you may use a workaround like storing data inside an item's nbt that the entity is wearing (e.g. having a button in mob's helmet, and storing data on that button).
+
+For reading/storing custom data on (block-)entities, you should use methods that end with ``PersistentData``.
 
 > [!IMPORTANT]
 > When working with block entities, make sure that the block entity exists in the world.

--- a/wiki/Using-the-NBT-API.md
+++ b/wiki/Using-the-NBT-API.md
@@ -192,7 +192,7 @@ Alternatively, you may safely modify ItemMeta inside the NBT scope:
 // Updating ItemMeta using NBT
 NBT.modify(itemStack, nbt -> {
     nbt.setInteger("kills", nbt.getOrDefault("kills", 0) + 1);
-    nbt.modifyMeta((meta, readOnlyNbt) -> { // Do not modify the nbt while modifying the meta!
+    nbt.modifyMeta((readOnlyNbt, meta) -> { // Do not modify the nbt while modifying the meta!
         meta.setDisplayName("Kills: " + readOnlyNbt.getOrDefault("kills", 0));
     });
     // Do more stuff


### PR DESCRIPTION
- Specify that persistent data storage for (block-)entities is 1.14+.
- Fixup arguments being swapped around in modifyMeta example.
	- Thanks to AlonsoAliaga for noticing this.
- Update gradle shadow plugin data.
- Add example for using paper-plugin.yml.