### PR TITLE
Add DataVersion for itemstack conversions

### DIFF
--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTContainer.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTContainer.java
@@ -21,6 +21,8 @@ public class NBTContainer extends NBTCompound {
 
     /**
      * Creates an empty, standalone NBTCompound
+     *
+     * @deprecated use {@link NBT#createNBTObject()}
      */
     @Deprecated
     public NBTContainer() {

--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTReflectionUtil.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTReflectionUtil.java
@@ -215,17 +215,16 @@ public class NBTReflectionUtil {
     public static Object convertNBTCompoundtoNMSItem(NBTCompound nbtcompound) {
         try {
             Object nmsComp = getToCompount(nbtcompound.getCompound(), nbtcompound);
-            if (MinecraftVersion.isAtLeastVersion(MinecraftVersion.MC1_12_R1) && nbtcompound.hasTag("DataVersion", NBTType.NBTTagInt)) {
-                int dataVersion = nbtcompound.getInteger("DataVersion");
-                int currentVersion = DataFixerUtil.getCurrentVersion();
-                if (dataVersion < currentVersion) {
-                    nmsComp = DataFixerUtil.fixUpRawItemData(nmsComp, dataVersion, currentVersion);
-                }
-            } else if (MinecraftVersion.isAtLeastVersion(MinecraftVersion.MC1_20_R4)
-                    && (nbtcompound.hasTag("tag") || nbtcompound.hasTag("Count"))) {
-                nmsComp = DataFixerUtil.fixUpRawItemData(nmsComp, DataFixerUtil.VERSION1_20_4, DataFixerUtil.getCurrentVersion());
-            }
             if (MinecraftVersion.isAtLeastVersion(MinecraftVersion.MC1_20_R4)) {
+                if (nbtcompound.hasTag("DataVersion", NBTType.NBTTagInt)) {
+                    int dataVersion = nbtcompound.getInteger("DataVersion");
+                    int currentVersion = DataFixerUtil.getCurrentVersion();
+                    if (dataVersion < currentVersion) {
+                        nmsComp = DataFixerUtil.fixUpRawItemData(nmsComp, dataVersion, currentVersion);
+                    }
+                } else if (nbtcompound.hasTag("tag") || nbtcompound.hasTag("Count")) {
+                    nmsComp = DataFixerUtil.fixUpRawItemData(nmsComp, DataFixerUtil.VERSION1_20_4, DataFixerUtil.getCurrentVersion());
+                }
                 return ReflectionMethod.NMSITEM_LOAD.run(null, registry_access, nmsComp);
             } else if (MinecraftVersion.getVersion().getVersionId() >= MinecraftVersion.MC1_11_R1.getVersionId()) {
                 return ObjectCreator.NMS_COMPOUNDFROMITEM.getInstance(nmsComp);

--- a/item-nbt-plugin/src/main/java/de/tr7zw/nbtapi/plugin/tests/items/ItemConversionTest.java
+++ b/item-nbt-plugin/src/main/java/de/tr7zw/nbtapi/plugin/tests/items/ItemConversionTest.java
@@ -1,13 +1,15 @@
 package de.tr7zw.nbtapi.plugin.tests.items;
 
+import de.tr7zw.changeme.nbtapi.NBT;
+import de.tr7zw.changeme.nbtapi.NBTType;
+import de.tr7zw.changeme.nbtapi.iface.ReadWriteNBT;
+import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import com.google.common.collect.Lists;
 
-import de.tr7zw.changeme.nbtapi.NBTContainer;
-import de.tr7zw.changeme.nbtapi.NBTItem;
 import de.tr7zw.changeme.nbtapi.NbtApiException;
 import de.tr7zw.nbtapi.plugin.tests.Test;
 
@@ -19,14 +21,21 @@ public class ItemConversionTest implements Test {
         ItemMeta meta = item.getItemMeta();
         meta.setLore(Lists.newArrayList("Firest Line", "Second Line"));
         item.setItemMeta(meta);
-        String nbt = NBTItem.convertItemtoNBT(item).toString();
-        if (!nbt.contains("Firest Line") || !nbt.contains("Second Line"))
-            throw new NbtApiException("The Item nbt '" + nbt + "' didn't contain the lore");
-        ItemStack rebuild = NBTItem.convertNBTtoItem(new NBTContainer(nbt));
+
+        ReadWriteNBT nbt = NBT.itemStackToNBT(item);
+        if (MinecraftVersion.isAtLeastVersion(MinecraftVersion.MC1_12_R1)
+                && !nbt.hasTag("DataVersion", NBTType.NBTTagInt)) {
+            throw new NbtApiException("The item nbt '" + nbt + "' didn't contain the data version");
+        }
+
+        String nbtString = nbt.toString();
+        if (!nbtString.contains("Firest Line") || !nbtString.contains("Second Line"))
+            throw new NbtApiException("The Item nbt '" + nbtString + "' didn't contain the lore");
+        ItemStack rebuild = NBT.itemStackFromNBT(NBT.parseNBT(nbtString));
         if (!item.isSimilar(rebuild))
             throw new NbtApiException("Rebuilt item did not match the original!");
 
-        NBTContainer cont = new NBTContainer();
+        ReadWriteNBT cont = NBT.createNBTObject();
         cont.setItemStack("testItem", item);
         if (!item.isSimilar(cont.getItemStack("testItem")))
             throw new NbtApiException("Rebuilt item did not match the original!");

--- a/item-nbt-plugin/src/main/java/de/tr7zw/nbtapi/plugin/tests/items/LegacyItemTest.java
+++ b/item-nbt-plugin/src/main/java/de/tr7zw/nbtapi/plugin/tests/items/LegacyItemTest.java
@@ -29,6 +29,10 @@ public class LegacyItemTest implements Test {
                 || !"test".equals(item.getItemMeta().getDisplayName())) {
             throw new NbtApiException("1.12.2 item didn't load correctly! " + item);
         }
+
+        ItemStack item2 = NBT.itemStackFromNBT(NBT.parseNBT("{DataVersion:" + DataFixerUtil.VERSION1_12_2 + ",id:cobblestone,Count:42,tag:{display:{Name:\"test\"},ench:[{lvl:3,id:34}]}}"));
+        if (!item.equals(item2))
+            throw new NbtApiException("Data-fixed 1.12.2 item didn't load correctly! " + item2);
     }
 
 }


### PR DESCRIPTION
Stores `DataVersion` (used by vanilla, also [Paper](https://github.com/PaperMC/Paper/blob/e0711af5d5b485ff507f5168c8c146689941421d/paper-server/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java#L528), for reference) on serialized itemstacks on 1.12.2+ (the lowest supported `DataFixerUtil.getCurrentVersion()`) and automatically goes through the data fixer upper on read (only on 1.20.5+, due to mappings) if the stored version is lower than the current one.

Closes https://github.com/tr7zw/Item-NBT-API/issues/318