### PR TITLE
Prevent NBTBlock read access from creating empty chunk PDC compounds

### DIFF
--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTBlock.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTBlock.java
@@ -1,8 +1,11 @@
 package de.tr7zw.changeme.nbtapi;
 
+import java.util.Set;
+
 import org.bukkit.block.Block;
 
 import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
+import de.tr7zw.changeme.nbtapi.utils.nmsmappings.ReflectionMethod;
 
 /**
  * Helper class to store NBT data to Block Locations. Use getData() to get the
@@ -31,8 +34,84 @@ public class NBTBlock {
     }
 
     public NBTCompound getData() {
-        return nbtChunk.getPersistentDataContainer().getOrCreateCompound("blocks")
-                .getOrCreateCompound(block.getX() + "_" + block.getY() + "_" + block.getZ());
+        return new NBTBlockCompound(nbtChunk.getPersistentDataContainer(), getBlockKey());
+    }
+
+    private String getBlockKey() {
+        return block.getX() + "_" + block.getY() + "_" + block.getZ();
+    }
+
+    private static final class NBTBlockCompound extends NBTCompound {
+
+        private final NBTCompound persistentDataContainer;
+        private final String blockKey;
+
+        private NBTBlockCompound(NBTCompound persistentDataContainer, String blockKey) {
+            super(null, null);
+            this.persistentDataContainer = persistentDataContainer;
+            this.blockKey = blockKey;
+        }
+
+        @Override
+        protected Object getResolvedObject() {
+            NBTCompound data = getExistingData();
+            if (data == null) {
+                return null;
+            }
+            return data.getResolvedObject();
+        }
+
+        @Override
+        public Object getCompound() {
+            NBTCompound data = getExistingData();
+            if (data == null) {
+                return null;
+            }
+            return data.getResolvedObject();
+        }
+
+        @Override
+        protected void prepareWrite() {
+            getOrCreateData();
+        }
+
+        @Override
+        protected void setCompound(Object compound) {
+            if (compound == null || isEmptyCompound(compound)) {
+                removeData();
+                return;
+            }
+            persistentDataContainer.getOrCreateCompound("blocks").set(blockKey, compound);
+        }
+
+        private NBTCompound getExistingData() {
+            NBTCompound blocks = persistentDataContainer.getCompound("blocks");
+            if (blocks == null) {
+                return null;
+            }
+            return blocks.getCompound(blockKey);
+        }
+
+        private NBTCompound getOrCreateData() {
+            return persistentDataContainer.getOrCreateCompound("blocks").getOrCreateCompound(blockKey);
+        }
+
+        private void removeData() {
+            NBTCompound blocks = persistentDataContainer.getCompound("blocks");
+            if (blocks == null) {
+                return;
+            }
+            blocks.removeKey(blockKey);
+            if (blocks.getKeys().isEmpty()) {
+                persistentDataContainer.removeKey("blocks");
+            }
+        }
+
+        private boolean isEmptyCompound(Object compound) {
+            @SuppressWarnings("unchecked")
+            Set<String> keys = (Set<String>) ReflectionMethod.COMPOUND_GET_KEYS.run(compound);
+            return keys.isEmpty();
+        }
     }
 
 }

--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTCompound.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTCompound.java
@@ -66,6 +66,12 @@ public class NBTCompound implements ReadWriteNBT {
             parent.saveCompound();
     }
 
+    /**
+     * Gives virtual compounds a chance to create their backing data before a write.
+     */
+    protected void prepareWrite() {
+    }
+
     protected void setResolvedObject(Object object) {
         if (isClosed()) {
             throw new NbtApiException("Tried using closed NBT data!");

--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTReflectionUtil.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTReflectionUtil.java
@@ -474,6 +474,7 @@ public class NBTReflectionUtil {
             remove(comp, name);
             return;
         }
+        comp.prepareWrite();
         Object nbttag = comp.getCompound();
         if (nbttag == null) {
             nbttag = ObjectCreator.NMS_NBTTAGCOMPOUND.getInstance();
@@ -543,6 +544,7 @@ public class NBTReflectionUtil {
         if (workingtagSrc == null) {
             return;
         }
+        comp.prepareWrite();
         Object rootnbttag = comp.getCompound();
         if (rootnbttag == null) {
             rootnbttag = ObjectCreator.NMS_NBTTAGCOMPOUND.getInstance();
@@ -570,6 +572,7 @@ public class NBTReflectionUtil {
             remove(comp, key);
             return;
         }
+        comp.prepareWrite();
         Object rootnbttag = comp.getCompound();
         if (rootnbttag == null) {
             rootnbttag = ObjectCreator.NMS_NBTTAGCOMPOUND.getInstance();
@@ -774,6 +777,7 @@ public class NBTReflectionUtil {
             remove(comp, key);
             return;
         }
+        comp.prepareWrite();
         Object rootnbttag = comp.getCompound();
         if (rootnbttag == null) {
             rootnbttag = ObjectCreator.NMS_NBTTAGCOMPOUND.getInstance();

--- a/item-nbt-plugin/src/main/java/de/tr7zw/nbtapi/plugin/tests/blocks/BlockNBTTest.java
+++ b/item-nbt-plugin/src/main/java/de/tr7zw/nbtapi/plugin/tests/blocks/BlockNBTTest.java
@@ -6,6 +6,8 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 
 import de.tr7zw.changeme.nbtapi.NBTBlock;
+import de.tr7zw.changeme.nbtapi.NBTChunk;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NbtApiException;
 import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
 import de.tr7zw.nbtapi.plugin.tests.Test;
@@ -23,7 +25,27 @@ public class BlockNBTTest implements Test {
                     Chunk chunk = world.getLoadedChunks()[0];
                     Block block = chunk.getBlock(0, 254, 0);
                     NBTBlock comp = new NBTBlock(block);
+                    NBTCompound persistentData = new NBTChunk(chunk).getPersistentDataContainer();
+                    String blockKey = block.getX() + "_" + block.getY() + "_" + block.getZ();
+                    NBTCompound blocks = persistentData.getCompound("blocks");
+                    if (blocks != null) {
+                        blocks.removeKey(blockKey);
+                        if (blocks.getKeys().isEmpty()) {
+                            persistentData.removeKey("blocks");
+                        }
+                    }
+                    if (comp.getData().hasTag("Too")) {
+                        throw new NbtApiException("Empty Block data reported an existing key!");
+                    }
+                    blocks = persistentData.getCompound("blocks");
+                    if (blocks != null && blocks.hasTag(blockKey)) {
+                        throw new NbtApiException("Reading empty Block data created a persistent block compound!");
+                    }
                     comp.getData().removeKey("Too");
+                    blocks = persistentData.getCompound("blocks");
+                    if (blocks != null && blocks.hasTag(blockKey)) {
+                        throw new NbtApiException("Removing a missing Block key created a persistent block compound!");
+                    }
                     if (comp.getData().hasTag("Too")) {
                         throw new NbtApiException("Unable to remove key from Block!");
                     }


### PR DESCRIPTION
## Summary

This PR prevents `NBTBlock#getData()` from creating persistent chunk PDC compounds during read-only access.

Currently, simply checking a tag like this:

```java
new NBTBlock(block).getData().hasTag("SomeKey");
```

creates the backing `blocks` compound and the block-location compound inside the chunk `PersistentDataContainer`, even when no data exists and the caller only wanted to read.

On larger servers, plugins may check many block locations. This can cause unnecessary persistent chunk data growth from empty compounds.

## Expected Behavior

Read-only access should not mutate chunk PDC data.

```java
new NBTBlock(block).getData().hasTag("SomeKey");
```

should only check whether the tag exists.

## Previous Behavior

`NBTBlock#getData()` used:

```java
getOrCreateCompound("blocks")
    .getOrCreateCompound(blockKey)
```

so even read-only access created persistent data.

## Changes

- `NBTBlock#getData()` now returns a lazy block compound wrapper.
- Missing block data is only created when a real write happens.
- Existing write behavior is preserved.
- Empty block compounds are cleaned up after removing the last key.
- Added a runtime test to ensure `hasTag` and `removeKey` on missing data do not create persistent block compounds.

## Compatibility

Existing write usage continues to work:

```java
new NBTBlock(block).getData().setString("SomeKey", "SomeValue");
```

The only behavior change is that read-only access no longer creates missing persistent compounds.
