### PR TITLE
Migrate NBTBlock & NBTChunk to NBT

### DIFF
--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBT.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBT.java
@@ -9,6 +9,9 @@ import java.util.logging.Level;
 
 import javax.annotation.Nullable;
 
+import de.tr7zw.changeme.nbtapi.utils.CheckUtil;
+import org.bukkit.Chunk;
+import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.Entity;
 import org.bukkit.inventory.ItemStack;
@@ -725,6 +728,208 @@ public class NBT {
         blockEnt.setCompound(cont);
         cont.setClosed();
         return val;
+    }
+
+    /**
+     * Reads block‑specific data that was previously stored in the chunk's
+     * persistent data container.
+     * <p>
+     * The data is stored inside the {@code blocks} compound of the chunk's
+     * persistent data container, using a key formed as {@code X_Y_Z} where
+     * X, Y, Z are the block's coordinates.
+     * <p>
+     * <b>Minecraft version:</b> this method requires <b>1.16.4 or newer</b>.
+     *
+     * @param block    the block whose stored data is to be read
+     * @param consumer the consumer that receives a {@link ReadableNBT} view of the data
+     */
+    public static void readChunkPDC(Block block, Consumer<ReadableNBT> consumer) {
+        processBlockChunkPDC(block, false, nbt -> {
+            consumer.accept(nbt);
+            return null;
+        });
+    }
+
+    /**
+     * Reads block‑specific data from the chunk's persistent data container and
+     * applies a function to produce a result.
+     * <p>
+     * The data is stored inside the {@code blocks} compound of the chunk's
+     * persistent data container, using a key formed as {@code X_Y_Z} where
+     * X, Y, Z are the block's coordinates.
+     * <p>
+     * <b>Minecraft version:</b> this method requires <b>1.16.4 or newer</b>.
+     *
+     * @param block    the block whose stored data is to be read
+     * @param function the function that processes the {@link ReadableNBT} and
+     *                 returns a value
+     * @param <T>      the type of the returned value
+     * @return the result of the function applied to the data
+     */
+    public static <T> T readAndGetChunkPDC(Block block, Function<ReadableNBT, T> function) {
+        return processBlockChunkPDC(block, false, function::apply);
+    }
+
+    /**
+     * Modifies block‑specific data stored in the chunk's persistent data container.
+     * <p>
+     * The data is stored inside the {@code blocks} compound of the chunk's
+     * persistent data container, using a key formed as {@code X_Y_Z} where
+     * X, Y, Z are the block's coordinates.
+     * <p>
+     * <b>Caution:</b> the data remains even if the block is broken, replaced, moved,
+     * or exploded, etc. You should manually remove the data when it is no longer needed.
+     * <p>
+     * <b>Minecraft version:</b> this method requires <b>1.16.4 or newer</b>.
+     *
+     * @param block    the block whose data is to be modified
+     * @param consumer the consumer that receives the {@link ReadWriteNBT} and
+     *                 applies modifications
+     */
+    public static void modifyChunkPDC(Block block, Consumer<ReadWriteNBT> consumer) {
+        processBlockChunkPDC(block, true, nbt -> {
+            consumer.accept(nbt);
+            return null;
+        });
+    }
+
+    /**
+     * Modifies block‑specific data in the chunk's persistent data container and
+     * returns a result computed from the modified data.
+     * <p>
+     * The data is stored inside the {@code blocks} compound of the chunk's
+     * persistent data container, using a key formed as {@code X_Y_Z} where
+     * X, Y, Z are the block's coordinates.
+     * <p>
+     * <b>Caution:</b> the data remains even if the block is broken, replaced, moved,
+     * or exploded, etc. You should manually remove the data when it is no longer needed.
+     * <p>
+     * <b>Minecraft version:</b> this method requires <b>1.16.4 or newer</b>.
+     *
+     * @param block    the block whose data is to be modified
+     * @param function the function that receives the {@link ReadWriteNBT}, modifies
+     *                 it, and returns a value
+     * @param <T>      the type of the returned value
+     * @return the result of the function after modification
+     */
+    public static <T> T modifyAndGetChunkPDC(Block block, Function<ReadWriteNBT, T> function) {
+        return processBlockChunkPDC(block, true, function::apply);
+    }
+
+    private static <T> T processBlockChunkPDC(Block block, boolean createIfAbsent, Function<NBTCompound, T> action) {
+        CheckUtil.assertAvailable(MinecraftVersion.MC1_16_R3);
+
+        String blockKey = block.getX() + "_" + block.getY() + "_" + block.getZ();
+
+        NBTCompound chunkData = new NBTPersistentDataContainer(block.getChunk().getPersistentDataContainer(), !createIfAbsent);
+
+        NBTCompound blocksData = createIfAbsent
+            ? chunkData.getOrCreateCompound("blocks")
+            : chunkData.getCompound("blocks");
+
+        NBTCompound blockData;
+        if (createIfAbsent) {
+            blockData = blocksData.getOrCreateCompound(blockKey);
+        } else {
+            blockData = blocksData == null ? null : blocksData.getCompound(blockKey);
+            if (blockData == null) {
+                blockData = new NBTContainer().setReadOnly(true);
+            }
+        }
+
+        T result = action.apply(blockData);
+
+        if (createIfAbsent) {
+            if (blockData.isEmpty()) {
+                blocksData.removeKey(blockKey);
+            }
+            if (blocksData.isEmpty()) {
+                chunkData.removeKey("blocks");
+            }
+        }
+
+        if (result instanceof ReadableNBT || result instanceof ReadableNBTList<?>) {
+            throw new NbtApiException("Tried returning part of the NBT to outside of the NBT scope!");
+        }
+
+        chunkData.setClosed();
+        return result;
+    }
+
+    /**
+     * Reads the chunk's persistent data container.
+     * <p>
+     * <b>Minecraft version:</b> this method requires <b>1.16.4 or newer</b>.
+     *
+     * @param chunk    the chunk whose persistent data is to be read
+     * @param consumer the consumer that receives a {@link ReadableNBT} view of the data
+     */
+    public static void readChunkPDC(Chunk chunk, Consumer<ReadableNBT> consumer) {
+        processChunkPDC(chunk, false, nbt -> {
+            consumer.accept(nbt);
+            return null;
+        });
+    }
+
+    /**
+     * Reads the chunk's persistent data container and applies a function to produce a result.
+     * <p>
+     * <b>Minecraft version:</b> this method requires <b>1.16.4 or newer</b>.
+     *
+     * @param chunk    the chunk whose persistent data is to be read
+     * @param function the function that processes the {@link ReadableNBT} and
+     *                 returns a value
+     * @param <T>      the type of the returned value
+     * @return the result of the function applied to the data
+     */
+    public static <T> T readAndGetChunkPDC(Chunk chunk, Function<ReadableNBT, T> function) {
+        return processChunkPDC(chunk, false, function::apply);
+    }
+
+    /**
+     * Modifies the chunk's persistent data container.
+     * <p>
+     * <b>Minecraft version:</b> this method requires <b>1.16.4 or newer</b>.
+     *
+     * @param chunk    the chunk whose persistent data is to be modified
+     * @param consumer the consumer that receives the {@link ReadWriteNBT} and
+     *                 applies modifications
+     */
+    public static void modifyChunkPDC(Chunk chunk, Consumer<ReadWriteNBT> consumer) {
+        processChunkPDC(chunk, true, nbt -> {
+            consumer.accept(nbt);
+            return null;
+        });
+    }
+
+    /**
+     * Modifies the chunk's persistent data container and returns a result computed from the modified data.
+     * <p>
+     * <b>Minecraft version:</b> this method requires <b>1.16.4 or newer</b>.
+     *
+     * @param chunk    the chunk whose persistent data is to be modified
+     * @param function the function that receives the {@link ReadWriteNBT}, modifies
+     *                 it, and returns a value
+     * @param <T>      the type of the returned value
+     * @return the result of the function after modification
+     */
+    public static <T> T modifyAndGetChunkPDC(Chunk chunk, Function<ReadWriteNBT, T> function) {
+        return processChunkPDC(chunk, true, function::apply);
+    }
+
+    private static <T> T processChunkPDC(Chunk chunk, boolean createIfAbsent, Function<NBTCompound, T> action) {
+        CheckUtil.assertAvailable(MinecraftVersion.MC1_16_R3);
+
+        NBTCompound chunkData = new NBTPersistentDataContainer(chunk.getPersistentDataContainer(), !createIfAbsent);
+
+        T result = action.apply(chunkData);
+
+        if (result instanceof ReadableNBT || result instanceof ReadableNBTList<?>) {
+            throw new NbtApiException("Tried returning part of the NBT to outside of the NBT scope!");
+        }
+
+        chunkData.setClosed();
+        return result;
     }
 
 }

--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBT.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBT.java
@@ -852,7 +852,6 @@ public class NBT {
             throw new NbtApiException("Tried returning part of the NBT to outside of the NBT scope!");
         }
 
-        chunkData.setClosed();
         return result;
     }
 
@@ -928,7 +927,6 @@ public class NBT {
             throw new NbtApiException("Tried returning part of the NBT to outside of the NBT scope!");
         }
 
-        chunkData.setClosed();
         return result;
     }
 

--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTBlock.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTBlock.java
@@ -7,16 +7,17 @@ import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
 /**
  * Helper class to store NBT data to Block Locations. Use getData() to get the
  * NBT instance. Important notes:
- * 
+ * <p>
  * - Non BlockEntities can not have NBT data. This stores the data to the chunk
  * instead!
- * 
+ * <p>
  * - The data is really just on the location. If the block gets
  * broken/changed/exploded/moved etc., the data is still on that location!
  * 
  * @author tr7zw
- *
+ * @deprecated use methods in {@link NBT} class to read/modify block's NBT
  */
+@Deprecated
 public class NBTBlock {
 
     private final Block block;
@@ -30,6 +31,13 @@ public class NBTBlock {
         nbtChunk = new NBTChunk(block.getChunk());
     }
 
+    /**
+     * Gets the block NBT data stored within the chunk's PDC.
+     *
+     * @return block NBT data
+     * @deprecated use methods in {@link NBT} class to read/modify block's NBT
+     */
+    @Deprecated
     public NBTCompound getData() {
         return nbtChunk.getPersistentDataContainer().getOrCreateCompound("blocks")
                 .getOrCreateCompound(block.getX() + "_" + block.getY() + "_" + block.getZ());

--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTChunk.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTChunk.java
@@ -5,6 +5,12 @@ import org.bukkit.Chunk;
 import de.tr7zw.changeme.nbtapi.utils.CheckUtil;
 import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
 
+/**
+ * Helper class to store NBT data to {@link Chunk}'s PDC (persistent data container).
+ *
+ * @deprecated use methods in {@link NBT} class to read/modify chunk's nbt
+ */
+@Deprecated
 public class NBTChunk {
 
     private final Chunk chunk;

--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTPersistentDataContainer.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/NBTPersistentDataContainer.java
@@ -11,7 +11,11 @@ public class NBTPersistentDataContainer extends NBTCompound {
     private final PersistentDataContainer container;
 
     public NBTPersistentDataContainer(PersistentDataContainer container) {
-        super(null, null);
+        this(container, false);
+    }
+
+    protected NBTPersistentDataContainer(PersistentDataContainer container, boolean readOnly) {
+        super(null, null, readOnly);
         this.container = container;
     }
 

--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/iface/ReadableNBT.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/iface/ReadableNBT.java
@@ -175,6 +175,15 @@ public interface ReadableNBT {
     Set<String> getKeys();
 
     /**
+     * Checks whether this NBT is empty (has no stored data).
+     *
+     * @return whether this NBT is empty
+     */
+    default boolean isEmpty() {
+        return getKeys().isEmpty();
+    }
+
+    /**
      * @param name
      * @return The Compound instance or null
      */
@@ -274,7 +283,7 @@ public interface ReadableNBT {
      * {@code Boolean, Byte, Short, Integer, Long, Float, Double, byte[], int[], long[]},
      * {@link String}, {@link UUID}, and {@link Enum}
      *
-     * @param key  Path key, seperated by '.'. For example: "foo.bar.baz". Dots can
+     * @param key  Path key, separated by '.'. For example: "foo.bar.baz". Dots can
      *             be escaped with a backslash.
      * @param type data type
      * @param <T>  value type
@@ -290,7 +299,7 @@ public interface ReadableNBT {
      * {@code Boolean, Byte, Short, Integer, Long, Float, Double, byte[], int[], long[]},
      * {@link String}, {@link UUID}, and {@link Enum}
      *
-     * @param key          Path key, seperated by '.'. For example: "foo.bar.baz".
+     * @param key          Path key, separated by '.'. For example: "foo.bar.baz".
      *                     Dots can be escaped with a backslash.
      * @param defaultValue default non-null value
      * @param <T>          value type
@@ -302,7 +311,7 @@ public interface ReadableNBT {
      * Returns the resolved Compound if exists, or null.
      * <p>
      * 
-     * @param key Path key, seperated by '.'. For example: "foo.bar.baz". Dots can
+     * @param key Path key, separated by '.'. For example: "foo.bar.baz". Dots can
      *            be escaped with a backslash.
      * @return The resolved value if exists, or null.
      */

--- a/item-nbt-plugin/src/main/java/de/tr7zw/nbtapi/plugin/tests/blocks/BlockNBTTest.java
+++ b/item-nbt-plugin/src/main/java/de/tr7zw/nbtapi/plugin/tests/blocks/BlockNBTTest.java
@@ -1,14 +1,18 @@
 package de.tr7zw.nbtapi.plugin.tests.blocks;
 
+import de.tr7zw.changeme.nbtapi.NBT;
+import de.tr7zw.changeme.nbtapi.NBTType;
+import de.tr7zw.changeme.nbtapi.iface.ReadableNBT;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 
-import de.tr7zw.changeme.nbtapi.NBTBlock;
 import de.tr7zw.changeme.nbtapi.NbtApiException;
 import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
 import de.tr7zw.nbtapi.plugin.tests.Test;
+
+import java.util.List;
 
 public class BlockNBTTest implements Test {
 
@@ -16,25 +20,58 @@ public class BlockNBTTest implements Test {
     public void test() throws Exception {
         if (MinecraftVersion.getVersion().getVersionId() < MinecraftVersion.MC1_16_R3.getVersionId())
             return;
-        if (!Bukkit.getWorlds().isEmpty()) {
-            World world = Bukkit.getWorlds().get(0);
-            try {
-                if (world.getLoadedChunks().length > 1) {
-                    Chunk chunk = world.getLoadedChunks()[0];
-                    Block block = chunk.getBlock(0, 254, 0);
-                    NBTBlock comp = new NBTBlock(block);
-                    comp.getData().removeKey("Too");
-                    if (comp.getData().hasTag("Too")) {
-                        throw new NbtApiException("Unable to remove key from Block!");
-                    }
-                    comp.getData().setString("Too", "Bar");
-                    if (!new NBTBlock(block).getData().getString("Too").equals("Bar")) {
-                        throw new NbtApiException("Custom Data did not save to a Block!");
-                    }
-                }
-            } catch (Exception ex) {
-                throw new NbtApiException("Wasn't able to use NBTBlocks!", ex);
+
+        List<World> loadedWorlds = Bukkit.getWorlds();
+        if (loadedWorlds.isEmpty())
+            return;
+
+        World world = loadedWorlds.get(0);
+        Chunk[] loadedChunks = world.getLoadedChunks();
+        if (loadedChunks.length == 0)
+            return;
+
+        try {
+            Chunk chunk = loadedChunks[0];
+            Block block = chunk.getBlock(0, 254, 0);
+            String blockKey = block.getX() + "_" + block.getY() + "_" + block.getZ();
+
+            NBT.modifyChunkPDC(block, nbt -> nbt.setString("Too", "Bar"));
+            boolean storedDataPresent = NBT.readAndGetChunkPDC(chunk, nbt -> {
+                if (!nbt.hasTag("blocks", NBTType.NBTTagCompound)) return false;
+
+                ReadableNBT blocksNbt = nbt.getCompound("blocks");
+                if (blocksNbt == null || !blocksNbt.hasTag(blockKey,  NBTType.NBTTagCompound)) return false;
+
+                ReadableNBT blockNbt =  blocksNbt.getCompound(blockKey);
+                return blockNbt != null && blockNbt.hasTag("Too", NBTType.NBTTagString) && "Bar".equals(blockNbt.getString("Too"));
+            });
+            if (!storedDataPresent) {
+                throw new NbtApiException("Custom Data did not save to a Block!");
             }
+            if (!NBT.readAndGetChunkPDC(block, nbt -> nbt.hasTag("Too"))) {
+                throw new NbtApiException("Custom Data did not save to a Block!");
+            }
+
+            boolean blockHadOnlyTestKey = NBT.readAndGetChunkPDC(block, nbt -> nbt.getKeys().size() == 1);
+            boolean chunkHadOnlyOneBlock = NBT.readAndGetChunkPDC(chunk, nbt -> nbt.getCompound("blocks").getKeys().size() == 1);
+
+            NBT.modifyChunkPDC(block, nbt -> nbt.removeKey("Too"));
+
+            if (NBT.readAndGetChunkPDC(block, nbt -> nbt.hasTag("Too"))) {
+                throw new NbtApiException("Unable to remove key from Block!");
+            }
+
+            if (chunkHadOnlyOneBlock) {
+               if (NBT.readAndGetChunkPDC(chunk, nbt -> nbt.hasTag("blocks"))) {
+                    throw new NbtApiException("Chunk data wasn't cleaned up (hanging \"blocks\" compound)!");
+                }
+            } else if (blockHadOnlyTestKey) {
+                if (NBT.readAndGetChunkPDC(chunk, nbt -> nbt.getCompound("blocks").hasTag(blockKey))) {
+                    throw new NbtApiException("Chunk data wasn't cleaned up (hanging block location compound)!");
+                }
+            }
+        } catch (Exception ex) {
+            throw new NbtApiException("Wasn't able to use NBTBlocks!", ex);
         }
     }
 

--- a/item-nbt-plugin/src/main/java/de/tr7zw/nbtapi/plugin/tests/chunks/ChunkNBTPersistentTest.java
+++ b/item-nbt-plugin/src/main/java/de/tr7zw/nbtapi/plugin/tests/chunks/ChunkNBTPersistentTest.java
@@ -1,14 +1,16 @@
 package de.tr7zw.nbtapi.plugin.tests.chunks;
 
+import de.tr7zw.changeme.nbtapi.NBT;
+import de.tr7zw.changeme.nbtapi.NBTType;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.World;
 
-import de.tr7zw.changeme.nbtapi.NBTChunk;
-import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NbtApiException;
 import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
 import de.tr7zw.nbtapi.plugin.tests.Test;
+
+import java.util.List;
 
 public class ChunkNBTPersistentTest implements Test {
 
@@ -16,25 +18,29 @@ public class ChunkNBTPersistentTest implements Test {
     public void test() throws Exception {
         if (MinecraftVersion.getVersion().getVersionId() < MinecraftVersion.MC1_16_R3.getVersionId())
             return;
-        if (!Bukkit.getWorlds().isEmpty()) {
-            World world = Bukkit.getWorlds().get(0);
-            try {
-                if (world.getLoadedChunks().length > 1) {
-                    Chunk chunk = world.getLoadedChunks()[0];
-                    NBTChunk comp = new NBTChunk(chunk);
-                    NBTCompound persistentData = comp.getPersistentDataContainer();
-                    persistentData.removeKey("Foo");
-                    if (persistentData.hasTag("Foo")) {
-                        throw new NbtApiException("Unable to remove key from Chunk!");
-                    }
-                    persistentData.setString("Foo", "Bar");
-                    if (!new NBTChunk(chunk).getPersistentDataContainer().getString("Foo").equals("Bar")) {
-                        throw new NbtApiException("Custom Data did not save to the Chunk!");
-                    }
-                }
-            } catch (Exception ex) {
-                throw new NbtApiException("Wasn't able to use NBTChunks!", ex);
+
+        List<World> loadedWorlds = Bukkit.getWorlds();
+        if (loadedWorlds.isEmpty())
+            return;
+
+        World world = loadedWorlds.get(0);
+        Chunk[] loadedChunks = world.getLoadedChunks();
+        if (loadedChunks.length == 0)
+            return;
+
+        Chunk chunk = loadedChunks[0];
+        try {
+            NBT.modifyChunkPDC(chunk, nbt -> nbt.setString("Foo", "Bar"));
+            if (!NBT.readAndGetChunkPDC(chunk, nbt -> nbt.hasTag("Foo", NBTType.NBTTagString) && "Bar".equals(nbt.getString("Foo")))) {
+                throw new NbtApiException("Custom Data did not save to the Chunk!");
             }
+
+            NBT.modifyChunkPDC(chunk, nbt -> nbt.removeKey("Foo"));
+            if (NBT.readAndGetChunkPDC(chunk, nbt -> nbt.hasTag("Foo"))) {
+                throw new NbtApiException("Unable to remove key from Chunk!");
+            }
+        } catch (Exception ex) {
+            throw new NbtApiException("Wasn't able to use NBTChunks!", ex);
         }
     }
 

--- a/wiki/Using-the-NBT-API.md
+++ b/wiki/Using-the-NBT-API.md
@@ -306,20 +306,26 @@ You can store data in block entities (block entities like chest, furnace, etc.) 
 
 Thus, you have to use your own block data storage to store custom block data.
 
-You can store data inside Chunks since 1.16.4, and NBT-API allows you to do so by using ``NBTChunk``:
+You can store data inside Chunks using their PDC (Persistent Data Container) since Minecraft **1.16.4**. The NBT‑API provides read and modify methods in the `NBT` class to interact with it:
 
 ```java
-ReadWriteNBT nbt = new NBTChunk(chunk).getPersistentDataContainer();
+// Read the entire PDC or a specific value
+NBT.readChunkPDC(chunk, nbt -> { /* ... */ });
+String str = NBT.readAndGetChunkPDC(chunk, nbt -> nbt.getOrNull("key", String.class));
 ```
 
-Similarly, there is ``NBTBlock``, which allows you to store block data inside chunk's data.
+For convenience, you can also pass Blocks into `NBT#read/modify[AndGet]ChunkPDC` methods to store block data inside Chunk's PDC.
+Blocks are stored inside their chunk's PDC under a `blocks` compound, using the block's location (`X_Y_Z`) as the key for a subcompound.
 
 ```java
-// Block's data will be stored in Chunk's data in "blocks.x_y_z" subtag
-ReadWriteNBT nbt = new NBTBlock(block).getData();
+// Modify and retrieve data for a specific block
+boolean bool = NBT.modifyAndGetChunkPDC(block, nbt -> {
+    nbt.setString("owner_name", "Player123");
+    return nbt.getOrDefault("key", false);
+});
 ```
 
-**However**, keep in mind that this data is linked only to the location, and if the block gets broken/changed/exploded/moved/etc., the data will still be on that location unless manually cleared/moved!
+**However**, keep in mind that the block's data is linked only to the location, and if the block gets broken/changed/exploded/moved/etc., the data will still be on that location unless manually cleared/moved!
 
 Moreover, since the data is stored inside a Chunk, this will increase the chunk's size on the disk.
 


### PR DESCRIPTION
Deprecates NBTBlock and NBTChunk in favor of new NBT methods:
```java
void readChunkPDC(Block block, Consumer<ReadableNBT> consumer);
T readAndGetChunkPDC(Block block, Function<ReadableNBT, T> function);
void modifyChunkPDC(Block block, Consumer<ReadWriteNBT> consumer);
T modifyAndGetChunkPDC(Block block, Function<ReadWriteNBT, T> function);
```
(methods also accept Chunk)

Supersedes #351