### PR TITLE
Fix 'GET_LIST' and 'OWN_TYPE' to their 'LEGACY' sufixed name on Forge at 1.7.10

### DIFF
--- a/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/utils/nmsmappings/Forge1710Mappings.java
+++ b/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/utils/nmsmappings/Forge1710Mappings.java
@@ -56,8 +56,8 @@ public class Forge1710Mappings {
         methodMap.put("COMPOUND_MERGE", "merge");// Only present on Crucible
         methodMap.put("COMPOUND_SET", "func_74782_a");
         methodMap.put("COMPOUND_GET", "func_74781_a");
-        methodMap.put("COMPOUND_GET_LIST", "func_150295_c");
-        methodMap.put("COMPOUND_OWN_TYPE", "func_74732_a");
+        methodMap.put("COMPOUND_GET_LIST_LEGACY", "func_150295_c");
+        methodMap.put("COMPOUND_OWN_TYPE_LEGACY", "func_74732_a");
         methodMap.put("COMPOUND_GET_FLOAT", "func_74760_g");
         methodMap.put("COMPOUND_GET_STRING", "func_74779_i");
         methodMap.put("COMPOUND_GET_INT", "func_74762_e");


### PR DESCRIPTION
At Crucible 1.7.10 some recent migrations and changes on the names of the actions 'getList' and 'ownType' received sufix 'LEGACY'. It was necessary to ajust them on their mapping as well.

After that self-tests worked normally at Crucible in 1.7.10

<img width="682" height="231" alt="image" src="https://github.com/user-attachments/assets/3b390dfd-a568-4c65-bf46-3bbdc45daf74" />
